### PR TITLE
Añade tablero "Todo", fichas con imagen clicable y limita descripción a 250 caracteres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# linkaloo.com
+# Linkadoo
+
+Aplicación web simple para guardar enlaces en tableros personales. Requiere PHP 8 y MySQL.
+
+## Archivos principales
+
+- `login.php` y `register.php` – autenticación de usuarios.
+- `logout.php` – cierre de sesión.
+- `panel_de_control.php` – administración de tableros y enlaces.
+- Carpeta `img/` – coloca aquí el logo `linkaloo_white.png` de la aplicación.
+
+El menú superior muestra el logo y las secciones **Tableros** y **Usuario**.
+La descripción de cada enlace se limita a 250 caracteres.

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.menu-toggle');
+  const menu = document.querySelector('.top-menu ul');
+  if (toggle && menu) {
+    toggle.addEventListener('click', () => {
+      menu.classList.toggle('show');
+    });
+  }
+
+  const buttons = document.querySelectorAll('.board-btn');
+  const cards = document.querySelectorAll('.link-cards .card');
+  const filter = (cat) => {
+    cards.forEach(card => {
+      card.style.display = (cat === 'all' || card.dataset.cat === cat) ? '' : 'none';
+    });
+  };
+
+  if (buttons.length) {
+    filter(buttons[0].dataset.cat);
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        buttons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        filter(btn.dataset.cat);
+      });
+    });
+  }
+
+  document.querySelectorAll('.delete-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      fetch('delete_link.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'id=' + encodeURIComponent(id)
+      }).then(res => res.json()).then(data => {
+        if (data.success) {
+          const card = btn.closest('.card');
+          if (card) card.remove();
+        }
+      });
+    });
+  });
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,35 @@
+body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;color:#fff;}
+.top-menu {background:#1DA1F2;color:#fff;display:flex;justify-content:space-between;align-items:center;padding:10px 20px;position:relative;}
+.top-menu nav {display:flex;align-items:center;}
+.top-menu a {color:#fff;text-decoration:none;margin-right:15px;}
+.top-menu .logo a {font-weight:bold;font-size:20px;margin-right:0;}
+.top-menu .logo img {height:40px;}
+.top-menu ul {list-style:none;display:flex;margin:0;padding:0;}
+.top-menu li {position:relative;}
+.menu-toggle {display:none;background:none;border:none;cursor:pointer;margin-right:15px;padding:0;}
+.menu-toggle span {display:block;width:25px;height:3px;background:#fff;margin:4px 0;}
+@media (max-width:600px){
+  .top-menu ul {flex-direction:column;display:none;background:#1DA1F2;position:absolute;top:60px;left:0;width:100%;padding:10px 0;}
+  .top-menu ul.show {display:flex;}
+  .menu-toggle {display:flex;flex-direction:column;justify-content:center;}
+  .top-menu a {margin:10px 15px;}
+}
+.content {background:#fff;color:#000;padding:20px;}
+
+.control-forms {display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-bottom:10px;}
+.control-forms form {display:flex;gap:5px;}
+.control-forms input,.control-forms select,.control-forms button {padding:5px;}
+
+.board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
+.board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
+.board-btn.active {background:#0d8ddc;}
+.link-cards {display:flex;flex-wrap:wrap;gap:15px;margin-top:20px;}
+.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;}
+.link-cards .card a {display:block;}
+.link-cards .card img {width:100%;height:auto;display:block;}
+.link-cards .card-body {padding:10px;}
+.link-cards .card-body h4 {margin:0 0 10px;font-size:16px;}
+.link-cards .card-body p {margin:0 0 10px;font-size:14px;}
+
+.link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
+

--- a/config.php
+++ b/config.php
@@ -1,0 +1,21 @@
+<?php
+// Database configuration for Linkadoo
+$host     = '82.223.84.165';
+$dbname   = 'smartlinks';
+$username = 'smartuserIOn0s';
+$password = 'WMCuxq@ts8s8g8^w';
+$charset  = 'utf8mb4';
+
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
+    $pdo = new PDO($dsn, $username, $password, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+?>

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,32 @@
+CREATE TABLE usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    pass_hash VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE categorias (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    nombre VARCHAR(100) NOT NULL,
+    color VARCHAR(20),
+    share_token VARCHAR(100),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+CREATE TABLE links (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    categoria_id INT NOT NULL,
+    url TEXT NOT NULL,
+    url_canonica TEXT,
+    titulo VARCHAR(255),
+    descripcion VARCHAR(250),
+    imagen TEXT,
+    favicon TEXT,
+    dominio VARCHAR(255),
+    etiquetas TEXT,
+    hash_url VARCHAR(255),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE CASCADE
+);

--- a/delete_link.php
+++ b/delete_link.php
@@ -1,0 +1,16 @@
+<?php
+require 'config.php';
+session_start();
+header('Content-Type: application/json');
+if(!isset($_SESSION['user_id'])){
+    echo json_encode(['success'=>false]);
+    exit;
+}
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if($id){
+    $stmt = $pdo->prepare('DELETE FROM links WHERE id = ? AND usuario_id = ?');
+    $stmt->execute([$id, $_SESSION['user_id']]);
+    echo json_encode(['success' => $stmt->rowCount() > 0]);
+} else {
+    echo json_encode(['success'=>false]);
+}

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,3 @@
+</div>
+</body>
+</html>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,36 @@
+<?php
+// Iniciar sesión solo si no se ha hecho ya
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Rambla:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/style.css">
+    <script src="/assets/main.js" defer></script>
+    <title>Linkadoo</title>
+</head>
+<body>
+<header class="top-menu">
+    <div class="logo"><a href="/panel_de_control.php"><img src="/img/linkaloo_white.png" alt="Linkadoo"></a></div>
+    <nav>
+        <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
+        <ul class="menu">
+            <li><a href="/panel_de_control.php">Tableros</a></li>
+            <?php if(isset($_SESSION['user_id'])): ?>
+                <li><a href="#"><?= htmlspecialchars($_SESSION['user_name'] ?? 'Usuario'); ?></a></li>
+                <li><a href="/logout.php">Salir</a></li>
+            <?php else: ?>
+                <li><a href="/login.php">Login</a></li>
+                <li><a href="/register.php">Registro</a></li>
+            <?php endif; ?>
+        </ul>
+    </nav>
+</header>
+<div class="content">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,8 @@
+<?php
+session_start();
+if(isset($_SESSION['user_id'])){
+    header('Location: panel_de_control.php');
+} else {
+    header('Location: login.php');
+}
+exit;

--- a/login.php
+++ b/login.php
@@ -1,0 +1,40 @@
+<?php
+require 'config.php';
+session_start();
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if ($email && $password) {
+        $stmt = $pdo->prepare('SELECT id, nombre, pass_hash FROM usuarios WHERE email = ?');
+        $stmt->execute([$email]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['pass_hash'])) {
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['user_name'] = $user['nombre'];
+            header('Location: panel_de_control.php');
+            exit;
+        } else {
+            $error = 'Usuario o contraseña incorrectos';
+        }
+    } else {
+        $error = 'Introduce email y contraseña';
+    }
+}
+include 'header.php';
+?>
+<h2>Iniciar sesión</h2>
+<?php if($error): ?><p style="color:red;"><?= $error ?></p><?php endif; ?>
+<form method="post">
+    <label>Email: <input type="email" name="email"></label><br>
+    <label>Contraseña: <input type="password" name="password"></label><br>
+    <button type="submit">Entrar</button>
+</form>
+<div class="social-login">
+    <p>O iniciar con:</p>
+    <a href="oauth.php?provider=google">Google</a> |
+    <a href="oauth.php?provider=facebook">Facebook</a> |
+    <a href="oauth.php?provider=instagram">Instagram</a>
+</div>
+<?php include 'footer.php'; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/oauth.php
+++ b/oauth.php
@@ -1,0 +1,9 @@
+<?php
+// Placeholder for OAuth social login
+$provider = $_GET['provider'] ?? '';
+header('Content-Type: text/plain');
+if(!$provider){
+    echo "Proveedor no especificado";
+    exit;
+}
+echo "Autenticación con $provider aún no implementada.";

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -1,0 +1,129 @@
+<?php
+require 'config.php';
+session_start();
+if(!isset($_SESSION['user_id'])){
+    header('Location: login.php');
+    exit;
+}
+$user_id = $_SESSION['user_id'];
+
+function scrapeMetadata($url){
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; LinkadooBot/1.0)',
+        CURLOPT_TIMEOUT => 5,
+    ]);
+    $html = curl_exec($ch);
+    curl_close($ch);
+    if(!$html){
+        return [];
+    }
+    libxml_use_internal_errors(true);
+    $doc = new DOMDocument();
+    $doc->loadHTML($html);
+    $xpath = new DOMXPath($doc);
+    $getMeta = function($name, $attr='property') use ($xpath){
+        $nodes = $xpath->query("//meta[@$attr='$name']/@content");
+        return $nodes->length ? trim($nodes->item(0)->nodeValue) : '';
+    };
+    $meta = [];
+    $titles = $doc->getElementsByTagName('title');
+    if($titles->length){
+        $meta['title'] = trim($titles->item(0)->textContent);
+    }
+    $meta['description'] = $getMeta('og:description') ?: $getMeta('description','name');
+    $meta['image'] = $getMeta('og:image') ?: $getMeta('twitter:image');
+    if(!empty($meta['image']) && !preg_match('#^https?://#', $meta['image'])){
+        $parts = parse_url($url);
+        $base = $parts['scheme'].'://'.$parts['host'];
+        if(isset($parts['port'])){
+            $base .= ':'.$parts['port'];
+        }
+        $meta['image'] = rtrim($base,'/').'/'.ltrim($meta['image'],'/');
+    }
+    return $meta;
+}
+
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    if(isset($_POST['categoria_nombre'])){
+        $categoria_nombre = trim($_POST['categoria_nombre']);
+        if($categoria_nombre){
+            $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+            $stmt->execute([$user_id, $categoria_nombre]);
+        }
+    } elseif(isset($_POST['link_url'])){
+        $link_url = trim($_POST['link_url']);
+        $link_title = trim($_POST['link_title']);
+        $categoria_id = (int)$_POST['categoria_id'];
+        if($link_url && $categoria_id){
+            $meta = scrapeMetadata($link_url);
+            if(!$link_title && !empty($meta['title'])){
+                $link_title = $meta['title'];
+            }
+            $descripcion = mb_substr($meta['description'] ?? '', 0, 250);
+            $imagen = $meta['image'] ?? '';
+            $hash = sha1($link_url);
+            $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?)');
+            $stmt->execute([$user_id, $categoria_id, $link_url, $link_title, $descripcion, $imagen, $hash]);
+        }
+    }
+}
+
+$stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ?');
+$stmt->execute([$user_id]);
+$categorias = $stmt->fetchAll();
+
+$stmtL = $pdo->prepare('SELECT id, categoria_id, url, titulo, descripcion, imagen FROM links WHERE usuario_id = ?');
+$stmtL->execute([$user_id]);
+$links = $stmtL->fetchAll();
+
+include 'header.php';
+?>
+<div class="control-forms">
+    <form method="post" class="form-categoria">
+        <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
+        <button type="submit">Crear tablero</button>
+    </form>
+    <form method="post" class="form-link">
+        <input type="url" name="link_url" placeholder="URL" required>
+        <input type="text" name="link_title" placeholder="Título">
+        <select name="categoria_id">
+        <?php foreach($categorias as $categoria): ?>
+            <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
+        <?php endforeach; ?>
+        </select>
+        <button type="submit">Guardar link</button>
+    </form>
+</div>
+
+<div class="board-slider">
+    <button class="board-btn active" data-cat="all">Todo</button>
+<?php foreach($categorias as $categoria): ?>
+    <button class="board-btn" data-cat="<?= $categoria['id'] ?>">
+        <?= htmlspecialchars($categoria['nombre']) ?>
+    </button>
+<?php endforeach; ?>
+</div>
+
+<div class="link-cards">
+<?php foreach($links as $link): ?>
+    <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
+        <?php if(!empty($link['imagen'])): ?>
+            <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
+                <img src="<?= htmlspecialchars($link['imagen']) ?>" alt="">
+            </a>
+        <?php endif; ?>
+        <div class="card-body">
+            <h4><?= htmlspecialchars($link['titulo'] ?: $link['url']) ?></h4>
+            <?php if(!empty($link['descripcion'])): ?>
+                <p><?= htmlspecialchars(mb_substr($link['descripcion'], 0, 250)) ?></p>
+            <?php endif; ?>
+        </div>
+        <button class="delete-btn" data-id="<?= $link['id'] ?>" aria-label="Borrar">🗑️</button>
+    </div>
+<?php endforeach; ?>
+</div>
+
+<?php include 'footer.php'; ?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,38 @@
+<?php
+require 'config.php';
+session_start();
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre = trim($_POST['nombre'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    if ($nombre && $email && $password) {
+        $stmt = $pdo->prepare('SELECT id FROM usuarios WHERE email = ?');
+        $stmt->execute([$email]);
+        if ($stmt->fetch()) {
+            $error = 'El email ya existe';
+        } else {
+            $hash = password_hash($password, PASSWORD_BCRYPT);
+            $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
+            $stmt->execute([$nombre, $email, $hash]);
+            $_SESSION['user_id'] = $pdo->lastInsertId();
+            $_SESSION['user_name'] = $nombre;
+            header('Location: panel_de_control.php');
+            exit;
+        }
+    } else {
+        $error = 'Rellena todos los campos';
+    }
+}
+include 'header.php';
+?>
+<h2>Registro</h2>
+<?php if($error): ?><p style="color:red;"><?= $error ?></p><?php endif; ?>
+<form method="post">
+    <label>Nombre: <input type="text" name="nombre"></label><br>
+    <label>Email: <input type="email" name="email"></label><br>
+    <label>Contraseña: <input type="password" name="password"></label><br>
+    <button type="submit">Registrarse</button>
+</form>
+<?php include 'footer.php'; ?>


### PR DESCRIPTION
## Resumen
- Se agregó un botón inicial "Todo" que muestra todas las fichas de enlaces
- Los formularios para crear tableros y guardar enlaces se muestran en línea sobre el carrusel de tableros
- Las fichas ya no muestran la URL y la imagen abre el enlace en una nueva pestaña
- La descripción de cada enlace se limita a 250 caracteres y la BBDD refleja este tope

## Pruebas
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b06e1c0258832c967711f1f7e465fd