### PR TITLE
Normalize database encoding, limit descriptions, enable card moves, add two-column mobile grid, and show link domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
 # Linkadoo
 
-Aplicación web simple para guardar enlaces en tableros personales. Requiere PHP 8 y MySQL.
+Aplicación web simple para guardar enlaces en tableros personales. Requiere PHP 8 y MySQL.
 
-## Archivos principales
+## Funcionalidades
 
-- `login.php` y `register.php` – autenticación de usuarios.
-- `logout.php` – cierre de sesión.
-- `panel_de_control.php` – administración de tableros y enlaces.
-- Carpeta `img/` – coloca aquí el logo `linkaloo_white.png` de la aplicación.
+- Autenticación de usuarios (`login.php`, `register.php`, `logout.php`).
+- Tableros para organizar enlaces y moverlos entre tableros.
+- Cada ficha muestra título (máximo 50 caracteres), descripción (máximo 250 con `...`), favicon y dominio.
+- Botón de compartir por ficha con la Web Share API o copia al portapapeles.
+- Menú desplegable en la parte inferior izquierda de cada ficha para moverla a otro tablero.
+- Grid responsivo: en móviles las fichas se distribuyen en dos columnas.
+- La altura de cada ficha se adapta a su contenido y no hay separación vertical entre fichas de una misma columna.
+- Base de datos en `utf8mb4` para almacenar caracteres especiales correctamente.
 
-El menú superior muestra el logo y las secciones **Tableros** y **Usuario**.
+## Instalación
+
+1. Crea una base de datos MySQL y ejecuta `database.sql`.
+2. Ajusta las credenciales en `config.php`.
+3. Coloca el logo `img/linkaloo_white.png`.
+4. Ejecuta un servidor PHP en la raíz del proyecto.
+
+## Desarrollo
+
+- JavaScript principal en `assets/main.js`.
+- Estilos en `assets/style.css`.
+- Para comprobar el código:
+  - `php -l config.php panel_de_control.php move_link.php`
+  - `node --check assets/main.js`
+  - `npx --yes stylelint assets/style.css` *(requiere configuración)*

--- a/assets/main.js
+++ b/assets/main.js
@@ -63,6 +63,24 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  document.querySelectorAll('.share-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const url = btn.dataset.url;
+      if (navigator.share) {
+        try {
+          await navigator.share({ url });
+        } catch (_) {}
+      } else if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(url);
+          const original = btn.textContent;
+          btn.textContent = '✅';
+          setTimeout(() => { btn.textContent = original; }, 2000);
+        } catch (_) {}
+      }
+    });
+  });
+
   const MAX_DESC = 250;
   document.querySelectorAll('.card-body p').forEach(p => {
     const text = p.textContent.trim();

--- a/assets/main.js
+++ b/assets/main.js
@@ -62,4 +62,12 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   });
+
+  const MAX_DESC = 250;
+  document.querySelectorAll('.card-body p').forEach(p => {
+    const text = p.textContent.trim();
+    if (text.length > MAX_DESC) {
+      p.textContent = text.slice(0, MAX_DESC - 3) + '...';
+    }
+  });
 });

--- a/assets/main.js
+++ b/assets/main.js
@@ -26,6 +26,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const slider = document.querySelector('.board-slider');
+  const left = document.querySelector('.board-scroll.left');
+  const right = document.querySelector('.board-scroll.right');
+  if (slider && left && right) {
+    const step = 100;
+    left.addEventListener('click', () => slider.scrollBy({left: -step, behavior: 'smooth'}));
+    right.addEventListener('click', () => slider.scrollBy({left: step, behavior: 'smooth'}));
+  }
+
   document.querySelectorAll('.delete-btn').forEach(btn => {
     btn.addEventListener('click', () => {
       const id = btn.dataset.id;

--- a/assets/main.js
+++ b/assets/main.js
@@ -41,4 +41,25 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   });
+
+  document.querySelectorAll('.move-select').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const id = sel.dataset.id;
+      const categoria = sel.value;
+      fetch('move_link.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'id=' + encodeURIComponent(id) + '&categoria_id=' + encodeURIComponent(categoria)
+      }).then(res => res.json()).then(data => {
+        if (data.success) {
+          const card = sel.closest('.card');
+          if (card) {
+            card.dataset.cat = categoria;
+            const active = document.querySelector('.board-btn.active');
+            if (active) filter(active.dataset.cat);
+          }
+        }
+      });
+    });
+  });
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -50,3 +50,18 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
   .board-scroll {display:none;}
 }
 
+/* Login page */
+.login-wrapper {display:flex;gap:20px;max-width:800px;margin:40px auto;flex-wrap:wrap;}
+.login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.login-form {display:flex;flex-direction:column;gap:10px;}
+.login-form input {padding:8px;}
+.login-form button {background:#1DA1F2;color:#fff;border:none;padding:10px;border-radius:4px;cursor:pointer;}
+.login-links {display:flex;justify-content:space-between;margin-top:10px;}
+.login-links a {color:#1DA1F2;text-decoration:none;font-size:14px;}
+.social-block {text-align:center;}
+.social-btn {display:block;margin:10px 0;padding:10px;border-radius:4px;color:#fff;text-decoration:none;}
+.social-btn.instagram {background:#E1306C;}
+.social-btn.google {background:#DB4437;}
+.social-btn.facebook {background:#4267B2;}
+@media (max-width:600px){.login-wrapper{flex-direction:column;}}
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -37,6 +37,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 
 .link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
+.link-cards .card .share-btn {position:absolute;bottom:5px;right:35px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
 .link-cards .card .move-select {position:absolute;bottom:5px;left:5px;padding:4px;}
 .link-cards .card .card-domain {margin-top:5px;text-align:center;font-size:16px;color:#1DA1F2;display:flex;align-items:center;justify-content:center;gap:4px;}
 .link-cards .card .card-domain img {width:16px;height:16px;}

--- a/assets/style.css
+++ b/assets/style.css
@@ -28,7 +28,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
-.link-cards {display:flex;flex-wrap:wrap;gap:15px;margin-top:20px;}
+.link-cards {display:flex;flex-wrap:wrap;gap:15px;margin-top:20px;align-items:flex-start;}
 .link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}

--- a/assets/style.css
+++ b/assets/style.css
@@ -17,14 +17,19 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .content {background:#fff;color:#000;padding:20px;}
 
 .control-forms {display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-bottom:10px;}
-.control-forms form {display:flex;gap:5px;}
-.control-forms input,.control-forms select,.control-forms button {padding:5px;}
+.control-forms form {display:flex;gap:5px;flex-wrap:wrap;align-items:flex-end;}
+.control-forms form input,
+.control-forms form select {flex:1 1 150px;}
+.control-forms form button {flex:0 0 auto;}
+.control-forms input,
+.control-forms select,
+.control-forms button {padding:5px;}
 
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
 .link-cards {display:flex;flex-wrap:wrap;gap:15px;margin-top:20px;}
-.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;}
+.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-body {padding:10px;}
@@ -32,4 +37,10 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 
 .link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
+.link-cards .card .move-select {position:absolute;bottom:5px;left:5px;padding:4px;}
+.link-cards .card .card-domain {position:absolute;bottom:5px;left:50%;transform:translateX(-50%);font-size:12px;color:#555;}
+
+@media (max-width:600px){
+  .link-cards .card {width:calc(50% - 10px);}
+}
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -28,7 +28,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
-.link-cards {display:flex;flex-wrap:wrap;gap:15px;margin-top:20px;align-items:flex-start;}
+.link-cards {display:flex;flex-wrap:wrap;gap:0 15px;margin-top:20px;align-items:flex-start;}
 .link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}

--- a/assets/style.css
+++ b/assets/style.css
@@ -38,7 +38,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 
 .link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
 .link-cards .card .move-select {position:absolute;bottom:5px;left:5px;padding:4px;}
-.link-cards .card .card-domain {position:absolute;bottom:5px;left:50%;transform:translateX(-50%);font-size:12px;color:#555;}
+.link-cards .card .card-domain {position:absolute;bottom:5px;left:0;width:100%;text-align:center;font-size:10px;color:#1DA1F2;}
 
 @media (max-width:600px){
   .link-cards .card {width:calc(50% - 10px);}

--- a/assets/style.css
+++ b/assets/style.css
@@ -28,7 +28,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
-.link-cards {display:flex;flex-wrap:wrap;gap:0 15px;margin-top:20px;align-items:flex-start;}
+.link-cards {display:flex;flex-wrap:wrap;gap:10px 15px;margin-top:20px;align-items:flex-start;}
 .link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}

--- a/assets/style.css
+++ b/assets/style.css
@@ -70,9 +70,9 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-create {display:flex;gap:5px;margin-bottom:20px;}
 .board-create input {flex:1;padding:5px;}
 .board-create button {padding:5px 10px;}
-.board-grid {display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:15px;list-style:none;margin:0;padding:0;}
+.board-grid {display:flex;flex-direction:column;gap:15px;list-style:none;margin:0;padding:0;}
 .board-item {position:relative;border:1px solid #eee;padding:10px;text-align:center;}
-.board-item img {width:100%;height:100px;object-fit:cover;margin-bottom:5px;}
+.board-item img {width:100%;height:auto;object-fit:contain;margin-bottom:5px;display:block;}
 .board-name {display:block;font-weight:bold;margin-bottom:5px;}
 .board-item .count {color:#1DA1F2;}
 .board-item form {position:absolute;top:5px;right:5px;margin:0;}

--- a/assets/style.css
+++ b/assets/style.css
@@ -25,7 +25,10 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .control-forms select,
 .control-forms button {padding:5px;}
 
-.board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;}
+.board-nav {display:flex;align-items:center;}
+.board-scroll {background:none;border:none;color:#1DA1F2;font-size:20px;cursor:pointer;padding:0 5px;}
+.board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;flex:1;scrollbar-width:none;-ms-overflow-style:none;}
+.board-slider::-webkit-scrollbar {display:none;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
 .link-cards {display:flex;flex-wrap:wrap;gap:10px 15px;margin-top:20px;align-items:flex-start;}
@@ -44,5 +47,6 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 
 @media (max-width:600px){
   .link-cards .card {width:calc(50% - 10px);}
+  .board-scroll {display:none;}
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -31,8 +31,8 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-slider::-webkit-scrollbar {display:none;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
-.link-cards {display:flex;flex-wrap:wrap;gap:10px 15px;margin-top:20px;align-items:flex-start;}
-.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:250px;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
+.link-cards {display:grid;grid-template-columns:repeat(6,1fr);gap:0 15px;margin-top:20px;align-items:start;}
+.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);position:relative;padding-bottom:50px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-body {padding:10px;}
@@ -45,8 +45,12 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .link-cards .card .card-domain {margin-top:5px;text-align:center;font-size:16px;color:#1DA1F2;display:flex;align-items:center;justify-content:center;gap:4px;}
 .link-cards .card .card-domain img {width:16px;height:16px;}
 
+@media (max-width:1024px){
+  .link-cards {grid-template-columns:repeat(4,1fr);}
+}
+
 @media (max-width:600px){
-  .link-cards .card {width:calc(50% - 10px);}
+  .link-cards {grid-template-columns:repeat(2,1fr);}
   .board-scroll {display:none;}
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -38,7 +38,7 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 
 .link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
 .link-cards .card .move-select {position:absolute;bottom:5px;left:5px;padding:4px;}
-.link-cards .card .card-domain {position:absolute;bottom:5px;left:0;width:100%;text-align:center;font-size:10px;color:#1DA1F2;}
+.link-cards .card .card-domain {margin-top:5px;text-align:center;font-size:16px;color:#1DA1F2;}
 
 @media (max-width:600px){
   .link-cards .card {width:calc(50% - 10px);}

--- a/assets/style.css
+++ b/assets/style.css
@@ -65,3 +65,14 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .social-btn.facebook {background:#4267B2;}
 @media (max-width:600px){.login-wrapper{flex-direction:column;}}
 
+/* Board management */
+.board-admin {max-width:600px;margin:0 auto;}
+.board-create {display:flex;gap:5px;margin-bottom:20px;}
+.board-create input {flex:1;padding:5px;}
+.board-create button {padding:5px 10px;}
+.board-list {list-style:none;margin:0;padding:0;}
+.board-list li {display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #eee;}
+.board-list li .count {color:#1DA1F2;}
+.board-list li form {margin:0;}
+.board-list .delete-board {background:none;border:none;cursor:pointer;font-size:16px;}
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -38,7 +38,8 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 
 .link-cards .card .delete-btn {position:absolute;bottom:5px;right:5px;background:rgba(255,255,255,0.9);border:none;border-radius:50%;padding:5px;cursor:pointer;font-size:16px;line-height:1;}
 .link-cards .card .move-select {position:absolute;bottom:5px;left:5px;padding:4px;}
-.link-cards .card .card-domain {margin-top:5px;text-align:center;font-size:16px;color:#1DA1F2;}
+.link-cards .card .card-domain {margin-top:5px;text-align:center;font-size:16px;color:#1DA1F2;display:flex;align-items:center;justify-content:center;gap:4px;}
+.link-cards .card .card-domain img {width:16px;height:16px;}
 
 @media (max-width:600px){
   .link-cards .card {width:calc(50% - 10px);}

--- a/assets/style.css
+++ b/assets/style.css
@@ -70,9 +70,11 @@ body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;co
 .board-create {display:flex;gap:5px;margin-bottom:20px;}
 .board-create input {flex:1;padding:5px;}
 .board-create button {padding:5px 10px;}
-.board-list {list-style:none;margin:0;padding:0;}
-.board-list li {display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #eee;}
-.board-list li .count {color:#1DA1F2;}
-.board-list li form {margin:0;}
-.board-list .delete-board {background:none;border:none;cursor:pointer;font-size:16px;}
+.board-grid {display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:15px;list-style:none;margin:0;padding:0;}
+.board-item {position:relative;border:1px solid #eee;padding:10px;text-align:center;}
+.board-item img {width:100%;height:100px;object-fit:cover;margin-bottom:5px;}
+.board-name {display:block;font-weight:bold;margin-bottom:5px;}
+.board-item .count {color:#1DA1F2;}
+.board-item form {position:absolute;top:5px;right:5px;margin:0;}
+.board-item .delete-board {background:none;border:none;cursor:pointer;font-size:16px;}
 

--- a/config.php
+++ b/config.php
@@ -10,6 +10,7 @@ $options = [
     PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     PDO::ATTR_EMULATE_PREPARES   => false,
+    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
 ];
 
 try {

--- a/database.sql
+++ b/database.sql
@@ -12,6 +12,7 @@ CREATE TABLE categorias (
     usuario_id INT NOT NULL,
     nombre VARCHAR(100) NOT NULL,
     color VARCHAR(20),
+    imagen TEXT,
     share_token VARCHAR(100),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database.sql
+++ b/database.sql
@@ -1,9 +1,11 @@
+SET NAMES utf8mb4;
+
 CREATE TABLE usuarios (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
     pass_hash VARCHAR(255) NOT NULL
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE categorias (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -12,7 +14,7 @@ CREATE TABLE categorias (
     color VARCHAR(20),
     share_token VARCHAR(100),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE links (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -29,4 +31,4 @@ CREATE TABLE links (
     hash_url VARCHAR(255),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database.sql
+++ b/database.sql
@@ -12,7 +12,6 @@ CREATE TABLE categorias (
     usuario_id INT NOT NULL,
     nombre VARCHAR(100) NOT NULL,
     color VARCHAR(20),
-    imagen TEXT,
     share_token VARCHAR(100),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database.sql
+++ b/database.sql
@@ -22,7 +22,7 @@ CREATE TABLE links (
     categoria_id INT NOT NULL,
     url TEXT NOT NULL,
     url_canonica TEXT,
-    titulo VARCHAR(255),
+    titulo VARCHAR(50),
     descripcion TEXT,
     imagen TEXT,
     favicon TEXT,

--- a/header.php
+++ b/header.php
@@ -22,8 +22,9 @@ if (session_status() === PHP_SESSION_NONE) {
     <nav>
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">
-            <li><a href="/panel_de_control.php">Tableros</a></li>
+            <li><a href="/panel_de_control.php">Inicio</a></li>
             <?php if(isset($_SESSION['user_id'])): ?>
+                <li><a href="/tableros.php">Tableros</a></li>
                 <li><a href="#"><?= htmlspecialchars($_SESSION['user_name'] ?? 'Usuario'); ?></a></li>
                 <li><a href="/logout.php">Salir</a></li>
             <?php else: ?>

--- a/login.php
+++ b/login.php
@@ -24,17 +24,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 include 'header.php';
 ?>
-<h2>Iniciar sesión</h2>
-<?php if($error): ?><p style="color:red;"><?= $error ?></p><?php endif; ?>
-<form method="post">
-    <label>Email: <input type="email" name="email"></label><br>
-    <label>Contraseña: <input type="password" name="password"></label><br>
-    <button type="submit">Entrar</button>
-</form>
-<div class="social-login">
-    <p>O iniciar con:</p>
-    <a href="oauth.php?provider=google">Google</a> |
-    <a href="oauth.php?provider=facebook">Facebook</a> |
-    <a href="oauth.php?provider=instagram">Instagram</a>
+<div class="login-wrapper">
+    <div class="login-block">
+        <h2>Iniciar sesión</h2>
+        <?php if($error): ?><p class="error"><?= $error ?></p><?php endif; ?>
+        <form method="post" class="login-form">
+            <input type="email" name="email" placeholder="Email">
+            <input type="password" name="password" placeholder="Contraseña">
+            <button type="submit">Entrar</button>
+        </form>
+        <div class="login-links">
+            <a href="register.php">Registrarse</a>
+            <a href="#">¿Olvidaste tu contraseña?</a>
+        </div>
+    </div>
+    <div class="social-block">
+        <h3>O ingresar con</h3>
+        <a class="social-btn instagram" href="oauth.php?provider=instagram">Instagram</a>
+        <a class="social-btn google" href="oauth.php?provider=google">Google</a>
+        <a class="social-btn facebook" href="oauth.php?provider=facebook">Facebook</a>
+    </div>
 </div>
 <?php include 'footer.php'; ?>

--- a/move_link.php
+++ b/move_link.php
@@ -1,0 +1,17 @@
+<?php
+require 'config.php';
+session_start();
+header('Content-Type: application/json');
+if(!isset($_SESSION['user_id'])){
+    echo json_encode(['success' => false]);
+    exit;
+}
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 0;
+if($id && $categoria_id){
+    $stmt = $pdo->prepare('UPDATE links SET categoria_id = ? WHERE id = ? AND usuario_id = ?');
+    $stmt->execute([$categoria_id, $id, $_SESSION['user_id']]);
+    echo json_encode(['success' => $stmt->rowCount() > 0]);
+} else {
+    echo json_encode(['success' => false]);
+}

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -142,6 +142,7 @@ include 'header.php';
             </option>
         <?php endforeach; ?>
         </select>
+        <button class="share-btn" data-url="<?= htmlspecialchars($link['url']) ?>" aria-label="Compartir">🔗</button>
         <button class="delete-btn" data-id="<?= $link['id'] ?>" aria-label="Borrar">🗑️</button>
     </div>
 <?php endforeach; ?>

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -130,7 +130,10 @@ include 'header.php';
                 <p><?= htmlspecialchars($desc) ?></p>
             <?php endif; ?>
             <?php $domain = parse_url($link['url'], PHP_URL_HOST); ?>
-            <div class="card-domain"><?= htmlspecialchars($domain) ?></div>
+            <div class="card-domain">
+                <img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" alt="">
+                <?= htmlspecialchars($domain) ?>
+            </div>
         </div>
         <select class="move-select" data-id="<?= $link['id'] ?>">
         <?php foreach($categorias as $categoria): ?>

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -62,6 +62,9 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             if(!$link_title && !empty($meta['title'])){
                 $link_title = $meta['title'];
             }
+            if (mb_strlen($link_title) > 50) {
+                $link_title = mb_substr($link_title, 0, 47) . '...';
+            }
             $descripcion = $meta['description'] ?? '';
             if (mb_strlen($descripcion) > 250) {
                 $descripcion = mb_substr($descripcion, 0, 247) . '...';
@@ -91,7 +94,7 @@ include 'header.php';
     </form>
     <form method="post" class="form-link">
         <input type="url" name="link_url" placeholder="URL" required>
-        <input type="text" name="link_title" placeholder="Título">
+        <input type="text" name="link_title" placeholder="Título" maxlength="50">
         <select name="categoria_id">
         <?php foreach($categorias as $categoria): ?>
             <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
@@ -119,7 +122,13 @@ include 'header.php';
             </a>
         <?php endif; ?>
         <div class="card-body">
-            <h4><?= htmlspecialchars($link['titulo'] ?: $link['url']) ?></h4>
+            <?php
+                $title = $link['titulo'] ?: $link['url'];
+                if (mb_strlen($title) > 50) {
+                    $title = mb_substr($title, 0, 47) . '...';
+                }
+            ?>
+            <h4><?= htmlspecialchars($title) ?></h4>
             <?php if(!empty($link['descripcion'])): ?>
                 <?php
                     $desc = $link['descripcion'];

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -63,6 +63,9 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $link_title = $meta['title'];
             }
             $descripcion = $meta['description'] ?? '';
+            if (mb_strlen($descripcion) > 250) {
+                $descripcion = mb_substr($descripcion, 0, 247) . '...';
+            }
             $imagen = $meta['image'] ?? '';
             $hash = sha1($link_url);
             $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?)');
@@ -109,7 +112,7 @@ include 'header.php';
 
 <div class="link-cards">
 <?php foreach($links as $link): ?>
-    <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
+        <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
         <?php if(!empty($link['imagen'])): ?>
             <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
                 <img src="<?= htmlspecialchars($link['imagen']) ?>" alt="">
@@ -118,9 +121,24 @@ include 'header.php';
         <div class="card-body">
             <h4><?= htmlspecialchars($link['titulo'] ?: $link['url']) ?></h4>
             <?php if(!empty($link['descripcion'])): ?>
-                <p><?= htmlspecialchars($link['descripcion']) ?></p>
+                <?php
+                    $desc = $link['descripcion'];
+                    if (mb_strlen($desc) > 250) {
+                        $desc = mb_substr($desc, 0, 247) . '...';
+                    }
+                ?>
+                <p><?= htmlspecialchars($desc) ?></p>
             <?php endif; ?>
         </div>
+        <?php $domain = parse_url($link['url'], PHP_URL_HOST); ?>
+        <div class="card-domain"><?= htmlspecialchars($domain) ?></div>
+        <select class="move-select" data-id="<?= $link['id'] ?>">
+        <?php foreach($categorias as $categoria): ?>
+            <option value="<?= $categoria['id'] ?>" <?= $categoria['id'] == $link['categoria_id'] ? 'selected' : '' ?>>
+                <?= htmlspecialchars($categoria['nombre']) ?>
+            </option>
+        <?php endforeach; ?>
+        </select>
         <button class="delete-btn" data-id="<?= $link['id'] ?>" aria-label="Borrar">🗑️</button>
     </div>
 <?php endforeach; ?>

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -101,13 +101,17 @@ include 'header.php';
     </form>
 </div>
 
-<div class="board-slider">
-    <button class="board-btn active" data-cat="all">Todo</button>
-<?php foreach($categorias as $categoria): ?>
-    <button class="board-btn" data-cat="<?= $categoria['id'] ?>">
-        <?= htmlspecialchars($categoria['nombre']) ?>
-    </button>
-<?php endforeach; ?>
+<div class="board-nav">
+    <button class="board-scroll left" aria-label="Anterior">&lt;</button>
+    <div class="board-slider">
+        <button class="board-btn active" data-cat="all">Todo</button>
+    <?php foreach($categorias as $categoria): ?>
+        <button class="board-btn" data-cat="<?= $categoria['id'] ?>">
+            <?= htmlspecialchars($categoria['nombre']) ?>
+        </button>
+    <?php endforeach; ?>
+    </div>
+    <button class="board-scroll right" aria-label="Siguiente">&gt;</button>
 </div>
 
 <div class="link-cards">

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -129,9 +129,9 @@ include 'header.php';
                 ?>
                 <p><?= htmlspecialchars($desc) ?></p>
             <?php endif; ?>
+            <?php $domain = parse_url($link['url'], PHP_URL_HOST); ?>
+            <div class="card-domain"><?= htmlspecialchars($domain) ?></div>
         </div>
-        <?php $domain = parse_url($link['url'], PHP_URL_HOST); ?>
-        <div class="card-domain"><?= htmlspecialchars($domain) ?></div>
         <select class="move-select" data-id="<?= $link['id'] ?>">
         <?php foreach($categorias as $categoria): ?>
             <option value="<?= $categoria['id'] ?>" <?= $categoria['id'] == $link['categoria_id'] ? 'selected' : '' ?>>

--- a/panel_de_control.php
+++ b/panel_de_control.php
@@ -66,9 +66,6 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $link_title = mb_substr($link_title, 0, 47) . '...';
             }
             $descripcion = $meta['description'] ?? '';
-            if (mb_strlen($descripcion) > 250) {
-                $descripcion = mb_substr($descripcion, 0, 247) . '...';
-            }
             $imagen = $meta['image'] ?? '';
             $hash = sha1($link_url);
             $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?)');
@@ -130,13 +127,7 @@ include 'header.php';
             ?>
             <h4><?= htmlspecialchars($title) ?></h4>
             <?php if(!empty($link['descripcion'])): ?>
-                <?php
-                    $desc = $link['descripcion'];
-                    if (mb_strlen($desc) > 250) {
-                        $desc = mb_substr($desc, 0, 247) . '...';
-                    }
-                ?>
-                <p><?= htmlspecialchars($desc) ?></p>
+                <p><?= htmlspecialchars($link['descripcion']) ?></p>
             <?php endif; ?>
             <?php $domain = parse_url($link['url'], PHP_URL_HOST); ?>
             <div class="card-domain">

--- a/register.php
+++ b/register.php
@@ -42,11 +42,13 @@ include 'header.php';
             <a href="#">¿Olvidaste tu contraseña?</a>
         </div>
     </div>
+    <!--
     <div class="social-block">
         <h3>O registrarte con</h3>
         <a class="social-btn instagram" href="oauth.php?provider=instagram">Instagram</a>
         <a class="social-btn google" href="oauth.php?provider=google">Google</a>
         <a class="social-btn facebook" href="oauth.php?provider=facebook">Facebook</a>
     </div>
+    -->
 </div>
 <?php include 'footer.php'; ?>

--- a/register.php
+++ b/register.php
@@ -27,12 +27,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 include 'header.php';
 ?>
-<h2>Registro</h2>
-<?php if($error): ?><p style="color:red;"><?= $error ?></p><?php endif; ?>
-<form method="post">
-    <label>Nombre: <input type="text" name="nombre"></label><br>
-    <label>Email: <input type="email" name="email"></label><br>
-    <label>Contraseña: <input type="password" name="password"></label><br>
-    <button type="submit">Registrarse</button>
-</form>
+<div class="login-wrapper">
+    <div class="login-block">
+        <h2>Registro</h2>
+        <?php if($error): ?><p class="error"><?= $error ?></p><?php endif; ?>
+        <form method="post" class="login-form">
+            <input type="text" name="nombre" placeholder="Nombre">
+            <input type="email" name="email" placeholder="Email">
+            <input type="password" name="password" placeholder="Contraseña">
+            <button type="submit">Registrarse</button>
+        </form>
+        <div class="login-links">
+            <a href="login.php">Iniciar sesión</a>
+            <a href="#">¿Olvidaste tu contraseña?</a>
+        </div>
+    </div>
+    <div class="social-block">
+        <h3>O registrarte con</h3>
+        <a class="social-btn instagram" href="oauth.php?provider=instagram">Instagram</a>
+        <a class="social-btn google" href="oauth.php?provider=google">Google</a>
+        <a class="social-btn facebook" href="oauth.php?provider=facebook">Facebook</a>
+    </div>
+</div>
 <?php include 'footer.php'; ?>

--- a/tableros.php
+++ b/tableros.php
@@ -22,13 +22,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-$stmt = $pdo->prepare('SELECT c.id, c.nombre, COUNT(l.id) AS total
+$stmt = $pdo->prepare('SELECT c.id, c.nombre,
+                              COUNT(l.id) AS total,
+                              COALESCE(c.imagen,
+                                      (SELECT l2.imagen FROM links l2
+                                       WHERE l2.categoria_id = c.id AND l2.usuario_id = ?
+                                       ORDER BY l2.id LIMIT 1)) AS imagen
                          FROM categorias c
                          LEFT JOIN links l ON l.categoria_id = c.id AND l.usuario_id = ?
                          WHERE c.usuario_id = ?
-                         GROUP BY c.id, c.nombre
+                         GROUP BY c.id, c.nombre, c.imagen
                          ORDER BY c.id');
-$stmt->execute([$user_id, $user_id]);
+$stmt->execute([$user_id, $user_id, $user_id]);
 $boards = $stmt->fetchAll();
 
 include 'header.php';
@@ -39,16 +44,20 @@ include 'header.php';
         <input type="text" name="board_name" placeholder="Nombre del tablero">
         <button type="submit">Crear</button>
     </form>
-    <ul class="board-list">
+    <div class="board-grid">
     <?php foreach($boards as $board): ?>
-        <li>
-            <span><?= htmlspecialchars($board['nombre']) ?> (<span class="count"><?= $board['total'] ?></span>)</span>
+        <div class="board-item">
+            <?php if(!empty($board['imagen'])): ?>
+                <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>">
+            <?php endif; ?>
+            <span class="board-name"><?= htmlspecialchars($board['nombre']) ?></span>
+            <span class="count"><?= $board['total'] ?></span>
             <form method="post">
                 <input type="hidden" name="delete_id" value="<?= $board['id'] ?>">
                 <button type="submit" class="delete-board" aria-label="Eliminar">🗑️</button>
             </form>
-        </li>
+        </div>
     <?php endforeach; ?>
-    </ul>
+    </div>
 </div>
 <?php include 'footer.php'; ?>

--- a/tableros.php
+++ b/tableros.php
@@ -1,0 +1,54 @@
+<?php
+require 'config.php';
+session_start();
+if(!isset($_SESSION['user_id'])){
+    header('Location: login.php');
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['board_name'])) {
+        $name = trim($_POST['board_name']);
+        if ($name) {
+            $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+            $stmt->execute([$user_id, $name]);
+        }
+    } elseif (isset($_POST['delete_id'])) {
+        $id = (int)$_POST['delete_id'];
+        $stmt = $pdo->prepare('DELETE FROM categorias WHERE id = ? AND usuario_id = ?');
+        $stmt->execute([$id, $user_id]);
+    }
+}
+
+$stmt = $pdo->prepare('SELECT c.id, c.nombre, COUNT(l.id) AS total
+                         FROM categorias c
+                         LEFT JOIN links l ON l.categoria_id = c.id AND l.usuario_id = ?
+                         WHERE c.usuario_id = ?
+                         GROUP BY c.id, c.nombre
+                         ORDER BY c.id');
+$stmt->execute([$user_id, $user_id]);
+$boards = $stmt->fetchAll();
+
+include 'header.php';
+?>
+<div class="board-admin">
+    <h2>Mis tableros</h2>
+    <form method="post" class="board-create">
+        <input type="text" name="board_name" placeholder="Nombre del tablero">
+        <button type="submit">Crear</button>
+    </form>
+    <ul class="board-list">
+    <?php foreach($boards as $board): ?>
+        <li>
+            <span><?= htmlspecialchars($board['nombre']) ?> (<span class="count"><?= $board['total'] ?></span>)</span>
+            <form method="post">
+                <input type="hidden" name="delete_id" value="<?= $board['id'] ?>">
+                <button type="submit" class="delete-board" aria-label="Eliminar">🗑️</button>
+            </form>
+        </li>
+    <?php endforeach; ?>
+    </ul>
+</div>
+<?php include 'footer.php'; ?>

--- a/tableros.php
+++ b/tableros.php
@@ -22,18 +22,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-$stmt = $pdo->prepare('SELECT c.id, c.nombre,
-                              COUNT(l.id) AS total,
-                              COALESCE(c.imagen,
-                                      (SELECT l2.imagen FROM links l2
-                                       WHERE l2.categoria_id = c.id AND l2.usuario_id = ?
-                                       ORDER BY l2.id LIMIT 1)) AS imagen
+$stmt = $pdo->prepare('SELECT c.id, c.nombre, COUNT(l.id) AS total
                          FROM categorias c
                          LEFT JOIN links l ON l.categoria_id = c.id AND l.usuario_id = ?
                          WHERE c.usuario_id = ?
-                         GROUP BY c.id, c.nombre, c.imagen
+                         GROUP BY c.id, c.nombre
                          ORDER BY c.id');
-$stmt->execute([$user_id, $user_id, $user_id]);
+$stmt->execute([$user_id, $user_id]);
 $boards = $stmt->fetchAll();
 
 include 'header.php';
@@ -44,20 +39,16 @@ include 'header.php';
         <input type="text" name="board_name" placeholder="Nombre del tablero">
         <button type="submit">Crear</button>
     </form>
-    <div class="board-grid">
+    <ul class="board-list">
     <?php foreach($boards as $board): ?>
-        <div class="board-item">
-            <?php if(!empty($board['imagen'])): ?>
-                <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>">
-            <?php endif; ?>
-            <span class="board-name"><?= htmlspecialchars($board['nombre']) ?></span>
-            <span class="count"><?= $board['total'] ?></span>
+        <li>
+            <span><?= htmlspecialchars($board['nombre']) ?> (<span class="count"><?= $board['total'] ?></span>)</span>
             <form method="post">
                 <input type="hidden" name="delete_id" value="<?= $board['id'] ?>">
                 <button type="submit" class="delete-board" aria-label="Eliminar">🗑️</button>
             </form>
-        </div>
+        </li>
     <?php endforeach; ?>
-    </div>
+    </ul>
 </div>
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- Truncate scraped and displayed descriptions to 250 characters with ellipsis
- Add dropdown and backend endpoint to move cards between boards
- Wrap board creation and link forms to prevent overflow on smaller screens
- Display card grid in two columns on narrow screens
- Normalize database connection and schema to store special characters correctly
- Show each link's domain centered at the bottom of its card

## Testing
- `php -l config.php`
- `php -l panel_de_control.php`
- `php -l move_link.php`
- `node --check assets/main.js`
- `npx --yes stylelint assets/style.css` *(fails: No configuration provided for /workspace/linkaloo.com/assets/style.css)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c0b9948c832c80978eaa6b214ee2