### PR TITLE
docs: add project overview and privacy policy

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+# Documentación del proyecto
+
+## Estructura general
+
+- `config.php`: configuración de la base de datos y creación del objeto `PDO` para todas las consultas.
+- `login.php`, `register.php`, `logout.php`: gestión de usuarios y sesiones.
+- `cambiar_password.php`, `recuperar_password.php`, `restablecer_password.php`: flujo completo de recuperación y cambio de contraseña.
+- `panel.php`: panel principal donde se crean tableros y se guardan enlaces. Incluye la función `scrapeMetadata` que obtiene título, descripción e imagen de una URL.
+- `load_links.php`: devuelve enlaces en formato JSON para la carga progresiva (scroll infinito).
+- `move_link.php` y `delete_link.php`: endpoints usados por AJAX para mover o borrar un enlace.
+- `editar_link.php`: permite añadir notas o ajustar datos de un enlace existente.
+- `database.sql`: define las tablas `usuarios`, `categorias` y `links`.
+- `assets/main.js`: controla el filtrado por tablero, la búsqueda, el compartido de enlaces, la paginación infinita y la interacción con los endpoints.
+- `assets/style.css`: estilos principales y diseño responsivo.
+
+## Flujo de uso
+
+1. El usuario se registra o inicia sesión.
+2. Desde el panel puede crear tableros y agregar enlaces. La metadata de cada URL se detecta automáticamente.
+3. La interfaz lista 18 enlaces iniciales y solicita más a `load_links.php` al llegar al final.
+4. Cada tarjeta permite mover, compartir o eliminar un enlace sin recargar la página.
+
+## Páginas informativas
+
+Las páginas `cookies.php`, `politica_cookies.php`, `condiciones_servicio.php`, `politica_privacidad.php`, `quienes_somos.php` e `index.php` ofrecen información estática y enlaces legales.
+
+Para instrucciones de instalación y pruebas consulte `README.md`.

--- a/politica_privacidad.php
+++ b/politica_privacidad.php
@@ -1,7 +1,30 @@
 <?php include 'header.php'; ?>
 <h1>Política de privacidad</h1>
-<p>Cómo protegemos y usamos tu información personal.</p>
+
+<h2>Información que recopilamos</h2>
+<p>Recopilamos datos personales que nos proporcionas al crear una cuenta o utilizar nuestros servicios, como nombre, correo electrónico y enlaces guardados.</p>
+
+<h2>Uso de la información</h2>
+<p>Usamos tu información para prestar y mejorar nuestros servicios, gestionar tu cuenta y comunicarnos contigo.</p>
+
+<h2>Compartición y divulgación</h2>
+<p>No compartimos tus datos personales con terceros salvo para cumplir obligaciones legales o con proveedores que nos ayudan a operar el servicio bajo acuerdos de confidencialidad.</p>
+
+<h2>Cookies</h2>
+<p>Empleamos cookies y tecnologías similares para recordar tus preferencias y analizar el uso de la plataforma. Puedes configurar tu navegador para rechazarlas.</p>
+
+<h2>Tus derechos</h2>
+<p>Puedes acceder, rectificar o eliminar tus datos personales, así como oponerte a su tratamiento, enviando una solicitud a nuestro correo de contacto.</p>
+
+<h2>Seguridad</h2>
+<p>Implementamos medidas de seguridad razonables para proteger tus datos, aunque ninguna transmisión o almacenamiento es completamente seguro.</p>
+
+<h2>Cambios en esta política</h2>
+<p>Podemos actualizar esta política ocasionalmente. Notificaremos sobre cambios significativos publicando la nueva versión en esta página.</p>
+
+<h2>Contacto</h2>
+<p>Si tienes preguntas sobre esta política, contáctanos en <a href="mailto:soporte@linkaloo.com">soporte@linkaloo.com</a>.</p>
+
 </div>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- Add project overview document detailing file structure and usage flow
- Expand privacy policy with sections on data handling and user rights

## Testing
- `php -l politica_privacidad.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b617de6e48832ca352cc808976eddf