### PR TITLE
Add PWA manifest and offline service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ favicon.ico
 img/favicon.png
 
 node_modules
+
+img/icon-192.png
+img/icon-512.png

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,4 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js');
+  }
+
   if (window.feather) {
     feather.replace();
   }

--- a/header.php
+++ b/header.php
@@ -14,6 +14,8 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0080ff">
+    <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/img/favicon.png" type="image/png">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "linkaloo",
+  "short_name": "linkaloo",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0080ff",
+  "icons": [
+    {
+      "src": "/img/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/img/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline - linkaloo</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Sin conexión</h1>
+  <p>No tienes conexión a internet. Inténtalo nuevamente más tarde.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,38 @@
+const CACHE_NAME = 'linkaloo-cache-v1';
+const OFFLINE_URL = '/offline.html';
+const ASSETS_TO_CACHE = [
+  '/',
+  OFFLINE_URL,
+  '/assets/style.css',
+  '/assets/main.js'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    );
+  } else {
+    event.respondWith(
+      caches.match(event.request).then((response) => response || fetch(event.request))
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add web app manifest with app metadata and icons
- add service worker with offline fallback page
- register service worker and link manifest in header
- remove binary PWA icons from version control and ignore them
- stop pre-caching icon assets in service worker

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b61ccedbc0832c92c6c0164dffc4ab