### PR TITLE
Add slider arrow controls for category navigation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -22,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let cards = Array.from(document.querySelectorAll('.link-cards .card'));
   const searchInput = document.querySelector('.search-input');
   const linkContainer = document.querySelector('.link-cards');
+  const boardSlider = document.querySelector('.board-slider');
+  const scrollLeft = document.querySelector('.board-scroll.left');
+  const scrollRight = document.querySelector('.board-scroll.right');
   const categoryOptions = document.querySelector('.form-link select') ? document.querySelector('.form-link select').innerHTML : '';
   let currentCat = 'all';
   const offsets = { all: cards.length };
@@ -37,6 +40,17 @@ document.addEventListener('DOMContentLoaded', () => {
       card.style.display = (inCat && matches) ? '' : 'none';
     });
   };
+
+  if (boardSlider && scrollLeft) {
+    scrollLeft.addEventListener('click', () => {
+      boardSlider.scrollBy({ left: -200, behavior: 'smooth' });
+    });
+  }
+  if (boardSlider && scrollRight) {
+    scrollRight.addEventListener('click', () => {
+      boardSlider.scrollBy({ left: 200, behavior: 'smooth' });
+    });
+  }
 
   if (buttons.length) {
     const params = new URLSearchParams(window.location.search);

--- a/assets/style.css
+++ b/assets/style.css
@@ -38,6 +38,8 @@ textarea {
 .toggle-forms svg{width:24px;height:24px;}
 .search-toggle{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;margin-left:5px;flex-shrink:0;}
 .search-toggle svg{width:20px;height:20px;}
+.board-scroll{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;flex-shrink:0;}
+.board-scroll svg{width:20px;height:20px;}
 .control-forms{display:none;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-bottom:10px;}
 .control-forms.show{display:flex;}
 .control-forms form{display:flex;gap:5px;flex-wrap:nowrap;align-items:flex-end;}

--- a/panel.php
+++ b/panel.php
@@ -101,6 +101,7 @@ include 'header.php';
 </div>
 <?php endif; ?>
 <div class="board-nav">
+    <button class="board-scroll left" aria-label="Anterior"><i data-feather="chevron-left"></i></button>
     <div class="board-slider">
         <button class="board-btn active" data-cat="all">Todo</button>
     <?php foreach($categorias as $categoria): ?>
@@ -109,6 +110,7 @@ include 'header.php';
         </button>
     <?php endforeach; ?>
     </div>
+    <button class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
     <button class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button>
     <button class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
 </div>


### PR DESCRIPTION
## Summary
- add left/right arrow buttons to category slider navigation
- style new slider controls
- enable smooth scrolling of category slider via arrow buttons

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68b844c21b80832ca746a9d6a2e0f2c8