### PR TITLE
Reduce mobile board item spacing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -145,6 +145,7 @@ textarea {
 
 @media (max-width:600px){
   .board-grid {grid-template-columns:repeat(2,1fr);}
+  .board-item {padding:5px;}
 }
 
 /* Board detail */


### PR DESCRIPTION
## Summary
- Tighten spacing between board tiles on small screens by reducing padding in mobile media query

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b849731c4c832c85eb5701715adc2d