### PR TITLE
feat: handle shared content

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.linkaloo">
+
+    <application>
+        <activity android:name=".ShareReceiverActivity" android:exported="true">
+            <!-- Un único enlace / texto -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+
+            <!-- Varios elementos (opcional) -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
## Summary
- allow ShareReceiverActivity to handle shared text and images with wildcard MIME types

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b84ced94c4832cbfb8fa8adf2363a9