### PR TITLE
Ocultar flechas del slider de categorías en móviles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -40,6 +40,7 @@ textarea {
 .search-toggle svg{width:20px;height:20px;}
 .board-scroll{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;flex-shrink:0;}
 .board-scroll svg{width:20px;height:20px;}
+@media (max-width:600px){.board-scroll{display:none;}}
 .control-forms{display:none;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-bottom:10px;}
 .control-forms.show{display:flex;}
 .control-forms form{display:flex;gap:5px;flex-wrap:nowrap;align-items:flex-end;}


### PR DESCRIPTION
## Summary
- Oculta los botones de flecha del carrusel de categorías cuando el ancho de pantalla es menor a 600px.

## Testing
- `npm run lint:css`
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ad174ac4832c9282df04f1dca2b0