### PR TITLE
Shift mobile logo left by 35px

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -31,6 +31,7 @@ textarea {
   /* Restore default hamburger bar size on mobile */
   .menu-toggle span {width:25px;height:3px;margin:4px 0;}
   .top-menu a {margin:20px 25px;font-size:20px;}
+  .top-menu .logo {margin-left:-35px;}
 }
 .content {background:#fff;color:#000;padding:20px;}
 


### PR DESCRIPTION
## Summary
- Move header logo 35px left on small screens

## Testing
- `npm run lint:css`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0872b18832ca40ad246a91b9462