### PR TITLE
Fix mobile menu spacing and settings alignment

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -23,16 +23,17 @@ textarea {
  .settings-menu .settings-submenu.show{display:block;}
  .settings-menu .settings-submenu li{padding:5px 15px;}
  .settings-menu .settings-submenu a{color:#fff;text-decoration:none;display:block;}
- @media (max-width:600px){.settings-menu .settings-submenu{position:static;}}
-@media (max-width:600px){
-  .top-menu ul {flex-direction:column;display:none;background:#1DA1F2;position:absolute;top:60px;left:0;width:100%;padding:10px 0;}
-  .top-menu ul.show {display:flex;}
-  .menu-toggle {display:flex;flex-direction:column;justify-content:center;}
-  /* Restore default hamburger bar size on mobile */
-  .menu-toggle span {width:25px;height:3px;margin:4px 0;}
-  .top-menu a {margin:20px 25px;font-size:20px;}
-  .top-menu .logo {margin-left:-35px;}
-}
+   @media (max-width:600px){.settings-menu {flex-direction:column;align-items:flex-start;}.settings-menu .settings-toggle{margin:0 25px;}.settings-menu .settings-submenu{position:static;width:100%;}}
+  @media (max-width:600px){
+    .top-menu ul {flex-direction:column;display:none;background:#1DA1F2;position:absolute;top:60px;left:0;width:100%;padding:10px 0;}
+    .top-menu ul.show {display:flex;}
+    .menu-toggle {display:flex;flex-direction:column;justify-content:center;}
+    /* Restore default hamburger bar size on mobile */
+    .menu-toggle span {width:25px;height:3px;margin:4px 0;}
+    .top-menu li {padding:10px 25px;}
+    .top-menu a {margin:0;font-size:20px;}
+    .top-menu .logo {margin-left:-35px;}
+  }
 .content {background:#fff;color:#000;padding:20px;}
 
 .toggle-forms{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:24px;margin-left:5px;flex-shrink:0;}


### PR DESCRIPTION
## Summary
- Reduce vertical spacing between mobile menu items
- Stack settings submenu below gear icon for proper alignment

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b8b28990a4832c9ce592bccc1d272a