### PR TITLE
Align mobile header elements

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -23,7 +23,7 @@ textarea {
  .settings-menu .settings-submenu.show{display:block;}
  .settings-menu .settings-submenu li{padding:5px 15px;}
  .settings-menu .settings-submenu a{color:#fff;text-decoration:none;display:block;}
-   @media (max-width:600px){.settings-menu {flex-direction:column;align-items:flex-start;}.settings-menu .settings-toggle{margin:0 25px;}.settings-menu .settings-submenu{position:static;width:100%;}}
+    @media (max-width:600px){.settings-menu {flex-direction:column;align-items:flex-start;}.settings-menu .settings-toggle{margin:0;}.settings-menu .settings-submenu{position:static;width:100%;}}
   @media (max-width:600px){
     .top-menu ul {flex-direction:column;display:none;background:#1DA1F2;position:absolute;top:60px;left:0;width:100%;padding:10px 0;}
     .top-menu ul.show {display:flex;}
@@ -32,7 +32,7 @@ textarea {
     .menu-toggle span {width:25px;height:3px;margin:4px 0;}
     .top-menu li {padding:10px 25px;}
     .top-menu a {margin:0;font-size:20px;}
-    .top-menu .logo {margin-left:-35px;}
+      .top-menu .logo {margin-left:-25px;}
   }
 .content {background:#fff;color:#000;padding:20px;}
 


### PR DESCRIPTION
## Summary
- left-align mobile settings gear icon
- nudge logo 10px right on small screens

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b4917358832ca8db1a8336275c72