### PR TITLE
Align mobile menu icon and shift logo

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -31,8 +31,10 @@ textarea {
     /* Restore default hamburger bar size on mobile */
     .menu-toggle span {width:25px;height:3px;margin:4px 0;}
     .top-menu li {padding:10px 25px;}
-    .top-menu a {margin:0;font-size:20px;}
-      .top-menu .logo {margin-left:-25px;}
+    .top-menu nav a {margin:0;font-size:20px;display:flex;align-items:center;justify-content:flex-start;}
+    .top-menu nav a svg,
+    .top-menu nav a img {margin-right:8px;}
+    .top-menu .logo {margin-left:-15px;}
   }
 .content {background:#fff;color:#000;padding:20px;}
 


### PR DESCRIPTION
## Summary
- align mobile menu icons to the left for clearer navigation
- move mobile logo 10px to the right for consistent spacing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b8b7416cd0832c8f39411743300297