### PR TITLE
Add standard legal and about page content

### DIFF
--- a/condiciones_servicio.php
+++ b/condiciones_servicio.php
@@ -1,7 +1,17 @@
 <?php include 'header.php'; ?>
 <h1>Condiciones de servicio</h1>
-<p>Términos y condiciones para el uso de linkaloo.</p>
+<p>El acceso y uso de linkaloo está sujeto a las siguientes condiciones. Al registrarte o utilizar el servicio aceptas estas condiciones en su totalidad.</p>
+<h2>Uso del servicio</h2>
+<p>linkaloo permite guardar y organizar enlaces personales. Debes utilizarlo de forma responsable y conforme a la ley.</p>
+<h2>Cuenta de usuario</h2>
+<p>Eres responsable de mantener la confidencialidad de tus credenciales y de todas las actividades que se realicen con tu cuenta.</p>
+<h2>Contenido</h2>
+<p>No está permitido publicar enlaces o descripciones que sean ilegales, ofensivos o que infrinjan derechos de terceros. Podemos eliminar cualquier contenido que incumpla estas normas.</p>
+<h2>Limitación de responsabilidad</h2>
+<p>linkaloo se ofrece "tal cual" sin garantías de disponibilidad ni de preservación de los datos. No nos hacemos responsables de los daños derivados del uso del servicio.</p>
+<h2>Modificaciones</h2>
+<p>Podemos modificar estas condiciones en cualquier momento. Las versiones actualizadas estarán disponibles en esta página.</p>
+<p>Para cualquier consulta puedes contactar con nosotros en <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
 </body>
 </html>
-

--- a/cookies.php
+++ b/cookies.php
@@ -1,7 +1,7 @@
 <?php include 'header.php'; ?>
-<h1>Cookies</h1>
-<p>Información sobre el uso de cookies en el sitio.</p>
+<h1>Uso de cookies</h1>
+<p>linkaloo utiliza cookies propias y de terceros para recordar tus preferencias, medir el uso del sitio y mejorar nuestros servicios.</p>
+<p>Al continuar navegando aceptas su uso. Puedes obtener más información o gestionar tus preferencias en nuestra <a href="/politica_cookies.php">Política de cookies</a>.</p>
 </div>
 </body>
 </html>
-

--- a/politica_cookies.php
+++ b/politica_cookies.php
@@ -1,7 +1,20 @@
 <?php include 'header.php'; ?>
 <h1>Política de cookies</h1>
-<p>Detalles sobre nuestra política de cookies.</p>
+<p>Esta política describe qué son las cookies, qué tipos utiliza linkaloo y cómo puedes controlarlas.</p>
+<h2>¿Qué son las cookies?</h2>
+<p>Las cookies son pequeños archivos de texto que se almacenan en tu dispositivo cuando visitas un sitio web. Sirven para recordar información sobre tu visita como tus preferencias o datos de acceso.</p>
+<h2>¿Qué cookies utiliza linkaloo?</h2>
+<ul>
+    <li><strong>Cookies necesarias:</strong> permiten el funcionamiento básico de la aplicación y la autenticación de usuarios.</li>
+    <li><strong>Cookies de análisis:</strong> nos ayudan a comprender cómo se utiliza el sitio para mejorarlo.</li>
+</ul>
+<h2>Cookies de terceros</h2>
+<p>En ocasiones utilizamos servicios externos que pueden instalar sus propias cookies, por ejemplo herramientas de analítica o redes sociales.</p>
+<h2>Gestión de cookies</h2>
+<p>Puedes permitir, bloquear o eliminar las cookies desde la configuración de tu navegador. Ten en cuenta que deshabilitar las cookies puede afectar al funcionamiento del servicio.</p>
+<h2>Actualizaciones</h2>
+<p>Podemos actualizar esta política para reflejar cambios legislativos o en el servicio. Te recomendamos revisarla periódicamente.</p>
+<p>Si tienes dudas, escríbenos a <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
 </body>
 </html>
-

--- a/politica_privacidad.php
+++ b/politica_privacidad.php
@@ -1,7 +1,25 @@
 <?php include 'header.php'; ?>
 <h1>Política de privacidad</h1>
-<p>Cómo protegemos y usamos tu información personal.</p>
+<p>En linkaloo respetamos tu privacidad y protegemos tus datos personales conforme al Reglamento (UE) 2016/679 (RGPD).</p>
+<h2>Responsable del tratamiento</h2>
+<p>El responsable es linkaloo. Puedes contactar en <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
+<h2>Datos que recopilamos</h2>
+<ul>
+    <li>Datos de registro: nombre de usuario, correo electrónico y contraseña encriptada.</li>
+    <li>Datos de uso: enlaces y tableros que guardas en la aplicación.</li>
+</ul>
+<h2>Finalidad</h2>
+<p>Tratamos tus datos para prestarte el servicio, gestionar tu cuenta y mejorar la plataforma.</p>
+<h2>Legitimación</h2>
+<p>La base legal para el tratamiento es tu consentimiento al registrarte y la necesidad de ejecutar el servicio solicitado.</p>
+<h2>Conservación</h2>
+<p>Los datos se conservarán mientras mantengas tu cuenta o solicites su eliminación.</p>
+<h2>Derechos</h2>
+<p>Puedes ejercitar tus derechos de acceso, rectificación, supresión, oposición, portabilidad y limitación enviando una petición a <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
+<h2>Seguridad</h2>
+<p>Aplicamos medidas técnicas y organizativas razonables para proteger tus datos frente a accesos no autorizados.</p>
+<h2>Cambios en la política</h2>
+<p>Podemos modificar esta política para adaptarla a novedades legislativas o de funcionamiento. Te avisaremos de los cambios significativos a través del servicio.</p>
 </div>
 </body>
 </html>
-

--- a/quienes_somos.php
+++ b/quienes_somos.php
@@ -1,7 +1,9 @@
 <?php include 'header.php'; ?>
 <h1>Quiénes somos</h1>
-<p>Conoce más sobre el equipo de linkaloo.</p>
+<p>linkaloo es una aplicación web creada para ayudarte a guardar y organizar tus enlaces favoritos en tableros personales.</p>
+<p>Nuestra misión es ofrecer una herramienta sencilla, privada y gratuita para que tengas a mano toda la información que te interesa.</p>
+<p>El proyecto es desarrollado por un pequeño equipo independiente que valora la privacidad y la experiencia de usuario.</p>
+<p>Si quieres ponerte en contacto con nosotros, escríbenos a <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- flesh out cookies page with overview of site cookie usage
- add detailed cookie policy, terms of service, privacy policy and about page text

## Testing
- `php -l cookies.php politica_cookies.php condiciones_servicio.php politica_privacidad.php quienes_somos.php`
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba64a3dc832cb5a09869ad0c950f