### PR TITLE
Fix encoding for stored titles and descriptions

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,6 +16,7 @@ $options = [
 try {
     $dsn = "mysql:host=$host;dbname=$dbname;charset=$charset";
     $pdo = new PDO($dsn, $username, $password, $options);
+    $pdo->exec("SET NAMES 'utf8mb4'");
 } catch (PDOException $e) {
     throw new PDOException($e->getMessage(), (int)$e->getCode());
 }

--- a/load_links.php
+++ b/load_links.php
@@ -29,6 +29,6 @@ foreach($links as &$link){
     }
 }
 unset($link);
-header('Content-Type: application/json');
-echo json_encode($links);
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($links, JSON_UNESCAPED_UNICODE);
 ?>


### PR DESCRIPTION
## Summary
- Normalize scraped metadata and user input to UTF-8 before saving
- Ensure DB connection and JSON output use UTF-8

## Testing
- `php -l panel.php`
- `php -l load_links.php`
- `php -l config.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9423a8d80832c9e63a1a793c98274