### PR TITLE
feat: add google oauth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,14 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
   - `node --check assets/main.js`
   - `npm run lint:css`
 
+
+## Login con Google
+
+1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
+2. Configura la pantalla de consentimiento en **APIs & Services → OAuth consent screen**.
+3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
+4. Añade `http://localhost:8000/oauth.php?provider=google` y la URL de producción en **Authorized redirect URIs**.
+5. Copia el *Client ID* y el *Client Secret*.
+6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno o edita `config.php` con esos valores.
+7. Usa el enlace "Google" en `login.php` para autenticarte.
+

--- a/config.php
+++ b/config.php
@@ -20,4 +20,9 @@ try {
 } catch (PDOException $e) {
     throw new PDOException($e->getMessage(), (int)$e->getCode());
 }
+
+// Google OAuth configuration
+$googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: 'YOUR_GOOGLE_CLIENT_ID';
+$googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: 'YOUR_GOOGLE_CLIENT_SECRET';
+$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'http://localhost:8000/oauth.php?provider=google';
 ?>

--- a/oauth.php
+++ b/oauth.php
@@ -1,9 +1,77 @@
 <?php
-// Placeholder for OAuth social login
+require 'config.php';
+session_start();
+
 $provider = $_GET['provider'] ?? '';
-header('Content-Type: text/plain');
-if(!$provider){
-    echo "Proveedor no especificado";
+
+if ($provider === 'google') {
+    if (!isset($_GET['code'])) {
+        $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query([
+            'client_id' => $googleClientId,
+            'redirect_uri' => $googleRedirectUri,
+            'response_type' => 'code',
+            'scope' => 'openid email profile',
+            'access_type' => 'online',
+            'prompt' => 'select_account'
+        ]);
+        header('Location: ' . $authUrl);
+        exit;
+    }
+
+    $code = $_GET['code'];
+    $tokenResponse = file_get_contents('https://oauth2.googleapis.com/token', false, stream_context_create([
+        'http' => [
+            'method' => 'POST',
+            'header' => 'Content-Type: application/x-www-form-urlencoded',
+            'content' => http_build_query([
+                'code' => $code,
+                'client_id' => $googleClientId,
+                'client_secret' => $googleClientSecret,
+                'redirect_uri' => $googleRedirectUri,
+                'grant_type' => 'authorization_code'
+            ])
+        ]
+    ]));
+    $tokenData = json_decode($tokenResponse, true);
+    if (!isset($tokenData['access_token'])) {
+        echo 'Error al obtener token de Google';
+        exit;
+    }
+    $userInfoResponse = file_get_contents('https://www.googleapis.com/oauth2/v2/userinfo', false, stream_context_create([
+        'http' => [
+            'header' => 'Authorization: Bearer ' . $tokenData['access_token']
+        ]
+    ]));
+    $userInfo = json_decode($userInfoResponse, true);
+    $email = $userInfo['email'] ?? '';
+    $name  = $userInfo['name'] ?? '';
+    if (!$email) {
+        echo 'Error al obtener información de usuario de Google';
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT id, nombre FROM usuarios WHERE email = ?');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if ($user) {
+        $userId   = $user['id'];
+        $userName = $user['nombre'];
+    } else {
+        $passHash = password_hash(bin2hex(random_bytes(16)), PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
+        $stmt->execute([$name ?: $email, $email, $passHash]);
+        $userId   = $pdo->lastInsertId();
+        $userName = $name ?: $email;
+    }
+    $_SESSION['user_id']   = $userId;
+    $_SESSION['user_name'] = $userName;
+    header('Location: panel.php');
     exit;
 }
-echo "Autenticación con $provider aún no implementada.";
+
+header('Content-Type: text/plain');
+if (!$provider) {
+    echo 'Proveedor no especificado';
+} else {
+    echo "Autenticación con $provider aún no implementada.";
+}
+?>


### PR DESCRIPTION
## Summary
- enable Google OAuth login and auto-register users
- document Google Cloud configuration steps

## Testing
- `php -l config.php`
- `php -l panel.php`
- `php -l move_link.php`
- `php -l load_links.php`
- `php -l oauth.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b944878a48832cb067901e888ca257