### PR TITLE
Fallback to domain logo when link image missing

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -178,12 +178,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const createCard = (link) => {
     const domain = new URL(link.url).hostname;
     const imgSrc = link.imagen ? link.imagen : 'https://www.google.com/s2/favicons?domain=' + encodeURIComponent(domain) + '&sz=128';
+    const isDefault = !link.imagen || link.imagen.includes('google.com/s2/favicons');
     const card = document.createElement('div');
     card.className = 'card';
     card.dataset.cat = link.categoria_id;
     card.dataset.id = link.id;
     card.innerHTML = `
-      <div class="card-image ${link.imagen ? '' : 'no-image'}">
+      <div class="card-image ${isDefault ? 'no-image' : ''}">
         <a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">
           <img src="${escapeHtml(imgSrc)}" alt="">
         </a>

--- a/panel.php
+++ b/panel.php
@@ -88,6 +88,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $descripcion = mb_substr($descripcion, 0, 247) . '...';
             }
             $imagen = $meta['image'] ?? '';
+            if (empty($imagen)) {
+                $domain = parse_url($link_url, PHP_URL_HOST);
+                if ($domain) {
+                    $imagen = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+                }
+            }
             $hash = sha1($link_url);
             $check = $pdo->prepare('SELECT id FROM links WHERE usuario_id = ? AND hash_url = ?');
             $check->execute([$user_id, $hash]);
@@ -156,9 +162,10 @@ include 'header.php';
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
         $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+        $isDefault = empty($link['imagen']) || strpos($link['imagen'], 'google.com/s2/favicons') !== false;
     ?>
     <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
-        <div class="card-image <?= empty($link['imagen']) ? 'no-image' : '' ?>">
+        <div class="card-image <?= $isDefault ? 'no-image' : '' ?>">
             <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
                 <img src="<?= htmlspecialchars($imgSrc) ?>" alt="">
             </a>


### PR DESCRIPTION
## Summary
- Store domain favicon as image when scraping metadata lacks an image
- Flag default favicon images so link cards show proper placeholder styling
- Apply same default favicon logic to dynamically created cards in the front-end

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b964c142e0832c842c6c1b8c805da5