### PR TITLE
docs: document OAuth callback redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
 1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
 2. Configura la pantalla de consentimiento en **APIs & Services → OAuth consent screen**.
 3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
-4. Añade `http://localhost:8000/oauth.php?provider=google` y la URL de producción en **Authorized redirect URIs**.
+4. Añade `http://localhost:8000/oauth.php?provider=google` (el endpoint de backend que maneja el callback OAuth) y la URL de producción en **Authorized redirect URIs**.
 5. Copia el *Client ID* y el *Client Secret*.
 6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno o edita `config.php` con esos valores.
 7. Usa el enlace "Google" en `login.php` para autenticarte.

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -34,4 +34,5 @@ La base de datos se define en `database.sql` y utiliza codificación `utf8mb4`.
 - Crea la base de datos ejecutando `database.sql`.
 - Define las credenciales en `config.php`.
 - Para el login con Google, configura las variables `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI`.
+- Registra `http://localhost:8000/oauth.php?provider=google` (o su URL de producción) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
 


### PR DESCRIPTION
## Summary
- Clarify that `oauth.php` is the backend endpoint handling the OAuth callback and must be registered as an authorized redirect URI.
- Document the same callback URI requirement in the project structure docs.

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b96af1a850832cb045fd1985981f35