### PR TITLE
Use environment variable for Google OAuth redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
 1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
 2. Configura la pantalla de consentimiento en **APIs & Services → OAuth consent screen**.
 3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
-4. Añade `http://localhost:8000/oauth.php?provider=google` (el endpoint de backend que maneja el callback OAuth) y la URL de producción en **Authorized redirect URIs**.
+4. Añade `http://localhost:8000/oauth.php?provider=google` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth.php?provider=google` en **Authorized redirect URIs**.
 5. Copia el *Client ID* y el *Client Secret*.
-6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno o edita `config.php` con esos valores.
+6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno (no hay fallback en `config.php`).
 7. Usa el enlace "Google" en `login.php` para autenticarte.
 

--- a/config.php
+++ b/config.php
@@ -24,5 +24,5 @@ try {
 // Google OAuth configuration
 $googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-293qjq63nfog07qge78no9v34tkjapec.apps.googleusercontent.com';
 $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
-$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'http://localhost:8000/oauth.php?provider=google';
+$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI'); // e.g., https://linkaloo.com/oauth.php?provider=google
 ?>


### PR DESCRIPTION
## Summary
- Require `GOOGLE_REDIRECT_URI` environment variable for Google OAuth and add example
- Document required production redirect URI and environment variable setup

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b97070b128832cb40493fed8a9a11d