### PR TITLE
Add Google OAuth callback endpoint

### DIFF
--- a/config.php
+++ b/config.php
@@ -24,5 +24,5 @@ try {
 // Google OAuth configuration
 $googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-293qjq63nfog07qge78no9v34tkjapec.apps.googleusercontent.com';
 $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
-$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI'); // e.g., https://linkaloo.com/oauth.php?provider=google
+$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback';
 ?>

--- a/oauth.php
+++ b/oauth.php
@@ -5,66 +5,15 @@ session_start();
 $provider = $_GET['provider'] ?? '';
 
 if ($provider === 'google') {
-    if (!isset($_GET['code'])) {
-        $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query([
-            'client_id' => $googleClientId,
-            'redirect_uri' => $googleRedirectUri,
-            'response_type' => 'code',
-            'scope' => 'openid email profile',
-            'access_type' => 'online',
-            'prompt' => 'select_account'
-        ]);
-        header('Location: ' . $authUrl);
-        exit;
-    }
-
-    $code = $_GET['code'];
-    $tokenResponse = file_get_contents('https://oauth2.googleapis.com/token', false, stream_context_create([
-        'http' => [
-            'method' => 'POST',
-            'header' => 'Content-Type: application/x-www-form-urlencoded',
-            'content' => http_build_query([
-                'code' => $code,
-                'client_id' => $googleClientId,
-                'client_secret' => $googleClientSecret,
-                'redirect_uri' => $googleRedirectUri,
-                'grant_type' => 'authorization_code'
-            ])
-        ]
-    ]));
-    $tokenData = json_decode($tokenResponse, true);
-    if (!isset($tokenData['access_token'])) {
-        echo 'Error al obtener token de Google';
-        exit;
-    }
-    $userInfoResponse = file_get_contents('https://www.googleapis.com/oauth2/v2/userinfo', false, stream_context_create([
-        'http' => [
-            'header' => 'Authorization: Bearer ' . $tokenData['access_token']
-        ]
-    ]));
-    $userInfo = json_decode($userInfoResponse, true);
-    $email = $userInfo['email'] ?? '';
-    $name  = $userInfo['name'] ?? '';
-    if (!$email) {
-        echo 'Error al obtener información de usuario de Google';
-        exit;
-    }
-    $stmt = $pdo->prepare('SELECT id, nombre FROM usuarios WHERE email = ?');
-    $stmt->execute([$email]);
-    $user = $stmt->fetch();
-    if ($user) {
-        $userId   = $user['id'];
-        $userName = $user['nombre'];
-    } else {
-        $passHash = password_hash(bin2hex(random_bytes(16)), PASSWORD_DEFAULT);
-        $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
-        $stmt->execute([$name ?: $email, $email, $passHash]);
-        $userId   = $pdo->lastInsertId();
-        $userName = $name ?: $email;
-    }
-    $_SESSION['user_id']   = $userId;
-    $_SESSION['user_name'] = $userName;
-    header('Location: panel.php');
+    $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query([
+        'client_id' => $googleClientId,
+        'redirect_uri' => $googleRedirectUri,
+        'response_type' => 'code',
+        'scope' => 'openid email profile',
+        'access_type' => 'online',
+        'prompt' => 'select_account'
+    ]);
+    header('Location: ' . $authUrl);
     exit;
 }
 

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -1,0 +1,69 @@
+<?php
+require 'config.php';
+session_start();
+
+if (!isset($_GET['code'])) {
+    echo 'Código de autorización no proporcionado';
+    exit;
+}
+
+$code = $_GET['code'];
+
+$tokenResponse = file_get_contents('https://oauth2.googleapis.com/token', false, stream_context_create([
+    'http' => [
+        'method' => 'POST',
+        'header' => 'Content-Type: application/x-www-form-urlencoded',
+        'content' => http_build_query([
+            'code' => $code,
+            'client_id' => $googleClientId,
+            'client_secret' => $googleClientSecret,
+            'redirect_uri' => $googleRedirectUri,
+            'grant_type' => 'authorization_code'
+        ])
+    ]
+]));
+
+$tokenData = json_decode($tokenResponse, true);
+
+if (!isset($tokenData['access_token'])) {
+    echo 'Error al obtener token de Google';
+    exit;
+}
+
+$userInfoResponse = file_get_contents('https://www.googleapis.com/oauth2/v2/userinfo', false, stream_context_create([
+    'http' => [
+        'header' => 'Authorization: Bearer ' . $tokenData['access_token']
+    ]
+]));
+
+$userInfo = json_decode($userInfoResponse, true);
+$email    = $userInfo['email'] ?? '';
+$name     = $userInfo['name'] ?? '';
+
+if (!$email) {
+    echo 'Error al obtener información de usuario de Google';
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT id, nombre FROM usuarios WHERE email = ?');
+$stmt->execute([$email]);
+$user = $stmt->fetch();
+
+if ($user) {
+    $userId   = $user['id'];
+    $userName = $user['nombre'];
+} else {
+    $passHash = password_hash(bin2hex(random_bytes(16)), PASSWORD_DEFAULT);
+    $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
+    $stmt->execute([$name ?: $email, $email, $passHash]);
+    $userId   = $pdo->lastInsertId();
+    $userName = $name ?: $email;
+}
+
+$_SESSION['user_id']   = $userId;
+$_SESSION['user_name'] = $userName;
+
+header('Location: panel.php');
+exit;
+?>
+


### PR DESCRIPTION
## Summary
- set default Google OAuth redirect URI to `/oauth2callback`
- simplify `oauth.php` to only start Google login
- add `oauth2callback.php` to process Google OAuth callback

## Testing
- `php -l oauth2callback.php`
- `php -l oauth.php`
- `npm test` *(fails: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b97a608090832ca7acaf48219cf494