### PR TITLE
fix: update Google OAuth callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
 1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
 2. Configura la pantalla de consentimiento en **APIs & Services → OAuth consent screen**.
 3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
-4. Añade `http://localhost:8000/oauth.php?provider=google` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth.php?provider=google` en **Authorized redirect URIs**.
+4. Añade `http://localhost:8000/oauth2callback.php` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth2callback` en **Authorized redirect URIs**.
 5. Copia el *Client ID* y el *Client Secret*.
-6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno (no hay fallback en `config.php`).
+6. Define `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` como variables de entorno (no hay fallback en `config.php`).
 7. Usa el enlace "Google" en `login.php` para autenticarte.
 

--- a/config.php
+++ b/config.php
@@ -24,5 +24,5 @@ try {
 // Google OAuth configuration
 $googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-293qjq63nfog07qge78no9v34tkjapec.apps.googleusercontent.com';
 $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
-$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback';
+$googleRedirectUri  = 'https://linkaloo.com/oauth2callback';
 ?>

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -33,6 +33,6 @@ La base de datos se define en `database.sql` y utiliza codificación `utf8mb4`.
 
 - Crea la base de datos ejecutando `database.sql`.
 - Define las credenciales en `config.php`.
-- Para el login con Google, configura las variables `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI`.
-- Registra `http://localhost:8000/oauth.php?provider=google` (o su URL de producción) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
+- Para el login con Google, configura las variables `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`.
+- Registra `http://localhost:8000/oauth2callback.php` (o `https://linkaloo.com/oauth2callback`) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
 


### PR DESCRIPTION
## Summary
- set Google OAuth redirect URI to https://linkaloo.com/oauth2callback
- document new callback URL in setup instructions

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68b989b99488832c98830e088659f742