### PR TITLE
Fix Google OAuth callback URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
 1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
 2. Configura la pantalla de consentimiento en **APIs & Services → OAuth consent screen**.
 3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
-4. Añade `http://localhost:8000/oauth2callback.php` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth2callback` en **Authorized redirect URIs**.
+4. Añade `http://localhost:8000/oauth2callback.php` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth2callback.php` en **Authorized redirect URIs**.
 5. Copia el *Client ID* y el *Client Secret*.
 6. Define `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` como variables de entorno (no hay fallback en `config.php`).
 7. Usa el enlace "Google" en `login.php` para autenticarte.

--- a/config.php
+++ b/config.php
@@ -24,5 +24,5 @@ try {
 // Google OAuth configuration
 $googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-293qjq63nfog07qge78no9v34tkjapec.apps.googleusercontent.com';
 $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
-$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback';
+$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback.php';
 ?>

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -34,5 +34,5 @@ La base de datos se define en `database.sql` y utiliza codificación `utf8mb4`.
 - Crea la base de datos ejecutando `database.sql`.
 - Define las credenciales en `config.php`.
 - Para el login con Google, configura las variables `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`.
-- Registra `http://localhost:8000/oauth2callback.php` (o `https://linkaloo.com/oauth2callback`) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
+- Registra `http://localhost:8000/oauth2callback.php` (o `https://linkaloo.com/oauth2callback.php`) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
 


### PR DESCRIPTION
## Summary
- correct Google OAuth redirect URI to include `oauth2callback.php`
- document proper redirect URI in README and docs

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b993494cd4832c986dcc84ea8da84c