### PR TITLE
Registra la respuesta de token de Google

### DIFF
--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -23,6 +23,8 @@ $tokenResponse = file_get_contents('https://oauth2.googleapis.com/token', false,
     ]
 ]));
 
+error_log($tokenResponse);
+
 $tokenData = json_decode($tokenResponse, true);
 
 if (!isset($tokenData['access_token'])) {


### PR DESCRIPTION
## Summary
- Añade `error_log` para imprimir la respuesta del token de Google y facilitar la depuración

## Testing
- `php -l oauth2callback.php`
- `npm test` *(falla: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b99cdf6060832c82bcec56ccdd17e5