### PR TITLE
Fix Google OAuth token retrieval

### DIFF
--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -9,36 +9,47 @@ if (!isset($_GET['code'])) {
 
 $code = $_GET['code'];
 
-$tokenResponse = file_get_contents('https://oauth2.googleapis.com/token', false, stream_context_create([
-    'http' => [
-        'method' => 'POST',
-        'header' => 'Content-Type: application/x-www-form-urlencoded',
-        'content' => http_build_query([
-            'code' => $code,
-            'client_id' => $googleClientId,
-            'client_secret' => $googleClientSecret,
-            'redirect_uri' => $googleRedirectUri,
-            'grant_type' => 'authorization_code'
-        ])
-    ]
-]));
+$ch = curl_init('https://oauth2.googleapis.com/token');
+curl_setopt_array($ch, [
+    CURLOPT_POST           => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => ['Content-Type: application/x-www-form-urlencoded'],
+    CURLOPT_POSTFIELDS     => http_build_query([
+        'code'          => $code,
+        'client_id'     => $googleClientId,
+        'client_secret' => $googleClientSecret,
+        'redirect_uri'  => $googleRedirectUri,
+        'grant_type'    => 'authorization_code',
+    ]),
+]);
 
-error_log($tokenResponse);
+$tokenResponse = curl_exec($ch);
+if ($tokenResponse === false) {
+    error_log('Error de cURL al obtener token: ' . curl_error($ch));
+}
+curl_close($ch);
 
-$tokenData = json_decode($tokenResponse, true);
+$tokenData = json_decode($tokenResponse, true) ?: [];
 
 if (!isset($tokenData['access_token'])) {
+    error_log('Respuesta de token no válida: ' . $tokenResponse);
     echo 'Error al obtener token de Google';
     exit;
 }
 
-$userInfoResponse = file_get_contents('https://www.googleapis.com/oauth2/v2/userinfo', false, stream_context_create([
-    'http' => [
-        'header' => 'Authorization: Bearer ' . $tokenData['access_token']
-    ]
-]));
+$ch = curl_init('https://www.googleapis.com/oauth2/v2/userinfo');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => ['Authorization: Bearer ' . $tokenData['access_token']],
+]);
 
-$userInfo = json_decode($userInfoResponse, true);
+$userInfoResponse = curl_exec($ch);
+if ($userInfoResponse === false) {
+    error_log('Error de cURL al obtener información de usuario: ' . curl_error($ch));
+}
+curl_close($ch);
+
+$userInfo = json_decode($userInfoResponse, true) ?: [];
 $email    = $userInfo['email'] ?? '';
 $name     = $userInfo['name'] ?? '';
 


### PR DESCRIPTION
## Summary
- Replace `file_get_contents` calls with cURL for Google OAuth token and userinfo requests
- Add error logging when cURL encounters problems or returns invalid token data

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b99f0b39e0832ca16485632799305c