### PR TITLE
feat: use Linkaloo icon on login page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -114,7 +114,7 @@ textarea {
 .login-wrapper {display:flex;gap:20px;max-width:800px;margin:0 auto;flex-wrap:wrap;min-height:calc(100vh - 80px);align-items:center;justify-content:center;}
 .login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .login-icon{text-align:center;margin-bottom:10px;}
-.login-icon svg{width:48px;height:48px;}
+.login-icon img,.login-icon svg{width:48px;height:48px;}
 .login-form {display:flex;flex-direction:column;gap:10px;}
 .login-form input {padding:8px;}
 .login-form button {background:#1DA1F2;color:#fff;border:none;padding:10px;border-radius:4px;cursor:pointer;}

--- a/login.php
+++ b/login.php
@@ -26,7 +26,7 @@ include 'header.php';
 ?>
 <div class="login-wrapper">
     <div class="login-block">
-        <div class="login-icon"><i data-feather="log-in"></i></div>
+        <div class="login-icon"><img src="/img/icon-512.png" alt="Linkaloo logo"><!-- Icon file already on server --></div>
         <h2>Iniciar sesión</h2>
         <?php if($error): ?><p class="error"><?= $error ?></p><?php endif; ?>
         <form method="post" class="login-form">


### PR DESCRIPTION
## Summary
- reference server-hosted Linkaloo icon on login page
- remove redundant Linkaloo logo asset

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9a3e551a0832c9b38bba84ef7d086