### PR TITLE
Restore white header logo and fix login logo proportions

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -114,7 +114,8 @@ textarea {
 .login-wrapper {display:flex;gap:20px;max-width:800px;margin:0 auto;flex-wrap:wrap;min-height:calc(100vh - 80px);align-items:center;justify-content:center;}
 .login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .login-icon{text-align:center;margin-bottom:10px;}
-.login-icon img,.login-icon svg{width:48px;height:48px;}
+.login-icon img{height:48px;width:auto;}
+.login-icon svg{width:48px;height:48px;}
 .login-form {display:flex;flex-direction:column;gap:10px;}
 .login-form input {padding:8px;}
 .login-form button {background:#1DA1F2;color:#fff;border:none;padding:10px;border-radius:4px;cursor:pointer;}

--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
 </head>
 <body>
 <header class="top-menu">
-    <div class="logo"><a href="/panel.php"><img src="/img/logo_linkaloo_blue.png" alt="linkaloo"><!-- Logo file already on server --></a></div>
+    <div class="logo"><a href="/panel.php"><img src="/img/linkaloo_white.png" alt="linkaloo"><!-- Logo file already on server --></a></div>
     <nav>
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">


### PR DESCRIPTION
## Summary
- revert header to use white logo asset
- ensure login page logo keeps its aspect ratio

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9d78710832cba2d8d49270ca644