### PR TITLE
Improve login page mobile layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -114,7 +114,7 @@ textarea {
 .login-wrapper {display:flex;gap:20px;max-width:800px;margin:0 auto;flex-wrap:wrap;min-height:calc(100vh - 80px);align-items:center;justify-content:center;}
 .login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .login-icon{text-align:center;margin-bottom:10px;}
-.login-icon img{height:48px;width:auto;}
+.login-icon img{height:85px;width:auto;}
 .login-icon svg{width:48px;height:48px;}
 .login-form {display:flex;flex-direction:column;gap:10px;}
 .login-form input {padding:8px;}
@@ -126,7 +126,10 @@ textarea {
 .social-btn.instagram {background:#E1306C;}
 .social-btn.google {background:#DB4437;}
 .social-btn.facebook {background:#4267B2;}
-@media (max-width:600px){.login-wrapper{flex-direction:column;}}
+@media (max-width:600px){
+  .login-wrapper{flex-direction:column;}
+  .login-block,.social-block{width:100%;}
+}
 
 /* Board management */
 .board-admin {margin:0 auto;}


### PR DESCRIPTION
## Summary
- increase login icon to 85px for better visibility
- make login blocks expand to full width on mobile screens

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9abcd22c0832c923afd3ebe78582b