### PR TITLE
Ajusta bloques grises en móvil al ancho de la pantalla

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,3 +1,6 @@
+*{
+  box-sizing:border-box;
+}
 body {font-family: 'Rambla', sans-serif;margin:0;padding:0;background:#1DA1F2;color:#fff;}
 input[type="text"],
 input[type="password"],


### PR DESCRIPTION
## Resumen
- Evita que los bloques grises se desborden por la derecha en móviles aplicando `box-sizing: border-box` globalmente.

## Pruebas
- `npm run lint:css`
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae013990832cb45410c7df207994