### PR TITLE
Limit card descriptions to 75 characters

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -184,6 +184,8 @@ document.addEventListener('DOMContentLoaded', () => {
     card.className = 'card';
     card.dataset.cat = link.categoria_id;
     card.dataset.id = link.id;
+    const desc = link.descripcion ? link.descripcion : '';
+    const shortDesc = desc.length > 75 ? desc.substring(0, 72) + '...' : desc;
     card.innerHTML = `
       <div class="card-image ${isDefault ? 'no-image' : ''}">
         <a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">
@@ -197,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
           <img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" width="20" height="20" alt="">
           <h4>${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
         </div>
-        ${link.descripcion ? `<p>${escapeHtml(link.descripcion)}</p>` : ''}
+        ${desc ? `<p>${escapeHtml(shortDesc)}</p>` : ''}
         <div class="card-actions">
           <select class="move-select" data-id="${link.id}">${categoryOptions}</select>
           <div class="action-btns">

--- a/load_links.php
+++ b/load_links.php
@@ -24,8 +24,8 @@ foreach($links as &$link){
     if(mb_strlen($link['titulo']) > 50){
         $link['titulo'] = mb_substr($link['titulo'], 0, 47) . '...';
     }
-    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 250){
-        $link['descripcion'] = mb_substr($link['descripcion'], 0, 247) . '...';
+    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 75){
+        $link['descripcion'] = mb_substr($link['descripcion'], 0, 72) . '...';
     }
 }
 unset($link);

--- a/panel.php
+++ b/panel.php
@@ -84,8 +84,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $link_title = mb_substr($link_title, 0, 47) . '...';
             }
             $descripcion = ensureUtf8($meta['description'] ?? '');
-            if (mb_strlen($descripcion) > 250) {
-                $descripcion = mb_substr($descripcion, 0, 247) . '...';
+            if (mb_strlen($descripcion) > 75) {
+                $descripcion = mb_substr($descripcion, 0, 72) . '...';
             }
             $imagen = $meta['image'] ?? '';
             if (empty($imagen)) {
@@ -186,8 +186,8 @@ include 'header.php';
             <?php if(!empty($link['descripcion'])): ?>
                 <?php
                     $desc = $link['descripcion'];
-                    if (mb_strlen($desc) > 250) {
-                        $desc = mb_substr($desc, 0, 247) . '...';
+                    if (mb_strlen($desc) > 75) {
+                        $desc = mb_substr($desc, 0, 72) . '...';
                     }
                 ?>
                 <p><?= htmlspecialchars($desc) ?></p>


### PR DESCRIPTION
## Summary
- Truncate link descriptions to 75 characters when scraping metadata
- Ensure card rendering shows at most 75 characters for descriptions
- Apply the same limit when loading more links via AJAX

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9b472eb10832ca643da10983f7f8d