### PR TITLE
Switch link card grid to masonry-style columns

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -79,8 +79,8 @@ textarea {
 .board-slider::-webkit-scrollbar {display:none;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
 .board-btn.active {background:#0d8ddc;}
-.link-cards {display:grid;grid-template-columns:repeat(6,1fr);gap:0 15px;margin-top:20px;align-items:start;}
-.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.link-cards {column-count:6;column-gap:15px;margin-top:20px;}
+.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);break-inside:avoid;margin-bottom:15px;}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-image{position:relative;}
@@ -105,11 +105,11 @@ textarea {
 .link-cards .card-actions .action-btns button svg{width:16px;height:16px;}
 
 @media (max-width:1024px){
-  .link-cards {grid-template-columns:repeat(4,1fr);}
+  .link-cards {column-count:4;}
 }
 
 @media (max-width:600px){
-  .link-cards {grid-template-columns:repeat(2,1fr);}
+  .link-cards {column-count:2;}
   .link-cards .card {margin-bottom:10px;}
 }
 


### PR DESCRIPTION
## Summary
- arrange link cards in Masonry-style columns

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68babdbc0a70832c956bebb4c8eb1146