### PR TITLE
Prevent duplicate link saves

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -35,6 +35,7 @@ CREATE TABLE links (
     etiquetas TEXT,
     hash_url VARCHAR(255),
     creado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_user_hash (usuario_id, hash_url),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- canonicalize URLs and check existing hash before inserting a link
- enforce unique link entries per user at the database level

## Testing
- `php -l panel.php`
- `npm test` *(fails: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bac1119c44832cb22e5dc82e45e930