### PR TITLE
Insert ad card every 16 links

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -27,16 +27,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const scrollRight = document.querySelector('.board-scroll.right');
   const categoryOptions = document.querySelector('.form-link select') ? document.querySelector('.form-link select').innerHTML : '';
   let currentCat = 'all';
-  const offsets = { all: cards.length };
   let loading = false;
+  let linkCount = cards.filter(c => !c.classList.contains('ad-card')).length;
+  const offsets = { all: linkCount };
   cards.forEach(c => {
-    const cat = c.dataset.cat;
-    offsets[cat] = (offsets[cat] || 0) + 1;
+    if (!c.classList.contains('ad-card')) {
+      const cat = c.dataset.cat;
+      offsets[cat] = (offsets[cat] || 0) + 1;
+    }
   });
   const filter = (cat, query = '') => {
     cards.forEach(card => {
-      const inCat = (cat === 'all' || card.dataset.cat === cat);
-      const matches = card.textContent.toLowerCase().includes(query);
+      const inCat = (cat === 'all' || card.dataset.cat === cat || card.classList.contains('ad-card'));
+      const matches = card.classList.contains('ad-card') || card.textContent.toLowerCase().includes(query);
       card.style.display = (inCat && matches) ? '' : 'none';
     });
   };
@@ -197,6 +200,24 @@ document.addEventListener('DOMContentLoaded', () => {
     return card;
   };
 
+  const createAdCard = () => {
+    const ad = document.createElement('div');
+    ad.className = 'card ad-card';
+    ad.dataset.cat = 'ad';
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    const ins = document.createElement('ins');
+    ins.setAttribute('data-revive-zoneid', '52');
+    ins.setAttribute('data-revive-id', 'cabd7431fd9e40f440e6d6f0c0dc8623');
+    body.appendChild(ins);
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = '//4bes.es/adserver/www/delivery/asyncjs.php';
+    body.appendChild(script);
+    ad.appendChild(body);
+    return ad;
+  };
+
   const loadMore = async () => {
     if (loading) return false;
     loading = true;
@@ -214,8 +235,16 @@ document.addEventListener('DOMContentLoaded', () => {
       attachCardEvents(card);
       const cat = String(link.categoria_id);
       offsets[cat] = (offsets[cat] || 0) + 1;
+      linkCount++;
+      if (linkCount % 16 === 0) {
+        const adCard = createAdCard();
+        linkContainer.appendChild(adCard);
+        cards.push(adCard);
+        attachCardEvents(adCard);
+      }
     });
     feather.replace();
+    offsets.all = linkCount;
     offsets[currentCat] = off + data.length;
     loading = false;
     return true;

--- a/panel.php
+++ b/panel.php
@@ -172,7 +172,7 @@ include 'header.php';
 </div>
 
 <div class="link-cards">
-<?php foreach($links as $link): ?>
+<?php foreach($links as $index => $link): ?>
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
         $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
@@ -217,6 +217,14 @@ include 'header.php';
             </div>
         </div>
     </div>
+    <?php if(($index + 1) % 16 === 0): ?>
+    <div class="card ad-card" data-cat="ad">
+        <div class="card-body">
+            <ins data-revive-zoneid="52" data-revive-id="cabd7431fd9e40f440e6d6f0c0dc8623"></ins>
+            <script async src="//4bes.es/adserver/www/delivery/asyncjs.php"></script>
+        </div>
+    </div>
+    <?php endif; ?>
 <?php endforeach; ?>
 </div>
 <div id="sentinel"></div>


### PR DESCRIPTION
## Summary
- Render ad snippet as a card after every 16 user links in `panel.php`
- Track link count and inject ad cards during infinite scroll while keeping them visible across filters

## Testing
- `php -l panel.php`
- `npm test` *(fails: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bb1fdbb6d8832c94a8cd9f97939306