### PR TITLE
Create default "Sin Categoria" board for new users

### DIFF
--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -70,6 +70,8 @@ if ($user) {
     $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
     $stmt->execute([$name ?: $email, $email, $passHash]);
     $userId   = $pdo->lastInsertId();
+    $catStmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+    $catStmt->execute([$userId, 'Sin Categoria']);
     $userName = $name ?: $email;
 }
 

--- a/register.php
+++ b/register.php
@@ -16,7 +16,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $hash = password_hash($password, PASSWORD_BCRYPT);
             $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
             $stmt->execute([$nombre, $email, $hash]);
-            $_SESSION['user_id'] = $pdo->lastInsertId();
+            $userId = $pdo->lastInsertId();
+            $catStmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+            $catStmt->execute([$userId, 'Sin Categoria']);
+            $_SESSION['user_id'] = $userId;
             $_SESSION['user_name'] = $nombre;
             header('Location: panel.php');
             exit;


### PR DESCRIPTION
## Summary
- Create a "Sin Categoria" board upon manual registration
- Ensure OAuth registrations also get a default board

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc3515e94c832cbf43c65437ac2a1b