### PR TITLE
feat: enable share target

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.linkaloo">
 
-    <application>
-         <activity android:name=".ShareReceiverActivity" android:exported="true">
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:label="Linkaloo">
+         <activity
+             android:name=".ShareReceiverActivity"
+             android:exported="true"
+             android:label="Guardar en Linkaloo">
              <!-- Un único enlace / texto -->
              <intent-filter>
                  <action android:name="android.intent.action.SEND" />

--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -32,6 +32,9 @@ class ShareReceiverActivity : AppCompatActivity() {
 
     private fun handleLink(link: String) {
         Log.d("ShareReceiver", "Received link: $link")
-        // TODO: procesar el enlace (link)
+        // Abre Linkaloo con el enlace compartido como parámetro
+        val encoded = Uri.encode(link)
+        val uri = Uri.parse("https://linkaloo.com/?shared=" + encoded)
+        startActivity(Intent(Intent.ACTION_VIEW, uri))
     }
 }


### PR DESCRIPTION
## Summary
- declare Linkaloo as a share target in the manifest
- open Linkaloo when handling shared links

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc379c2ad0832c990986eee2c2531a