### PR TITLE
Fix Android back navigation cache miss

### DIFF
--- a/header.php
+++ b/header.php
@@ -3,8 +3,8 @@
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
-// Evitar caché de contenido dinámico
-header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+// Evitar caché persistente, pero permitir que el navegador recargue al volver atrás
+header('Cache-Control: no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 $cssVersion = filemtime(__DIR__ . '/assets/style.css');
 $jsVersion  = filemtime(__DIR__ . '/assets/main.js');

--- a/panel.php
+++ b/panel.php
@@ -6,7 +6,9 @@ if(!isset($_SESSION['user_id'])){
     exit;
 }
 $user_id = $_SESSION['user_id'];
-$error = '';
+// Recuperar mensajes de error tras un posible redirect
+$error = $_SESSION['panel_error'] ?? '';
+unset($_SESSION['panel_error']);
 
 function ensureUtf8($string){
     $encoding = mb_detect_encoding($string, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
@@ -112,13 +114,15 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             $check = $pdo->prepare('SELECT id FROM links WHERE usuario_id = ? AND hash_url = ?');
             $check->execute([$user_id, $hash]);
             if($check->fetch()){
-                $error = 'Este link ya está guardado.';
+                $_SESSION['panel_error'] = 'Este link ya está guardado.';
             } else {
                 $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, url_canonica, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
                 $stmt->execute([$user_id, $categoria_id, $link_url, $canon, $link_title, $descripcion, $imagen, $hash]);
             }
         }
     }
+    header('Location: panel.php');
+    exit;
 }
 
 $stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY creado_en DESC');


### PR DESCRIPTION
## Summary
- Preserve back navigation by avoiding `no-store` header and redirecting after POST in panel

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a418978832c9292f8fe6c5b82ed