### PR TITLE
Fix board slider links to show filtered panel view

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -77,7 +77,7 @@ textarea {
 .board-nav {display:flex;align-items:center;gap:5px;margin-bottom:10px;}
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;flex:1;scrollbar-width:none;-ms-overflow-style:none;}
 .board-slider::-webkit-scrollbar {display:none;}
-.board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;}
+.board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;text-decoration:none;display:inline-block;}
 .board-btn.active {background:#0d8ddc;}
 .link-cards {column-count:6;column-gap:15px;margin-top:20px;}
 .link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);break-inside:avoid;margin-bottom:15px;}

--- a/panel.php
+++ b/panel.php
@@ -142,18 +142,18 @@ include 'header.php';
 </div>
 <?php endif; ?>
 <div class="board-nav">
-    <button class="board-scroll left" aria-label="Anterior"><i data-feather="chevron-left"></i></button>
+    <button type="button" class="board-scroll left" aria-label="Anterior"><i data-feather="chevron-left"></i></button>
     <div class="board-slider">
-        <button class="board-btn active" data-cat="all">Todo</button>
+        <a href="panel.php" class="board-btn" data-cat="all">Todo</a>
     <?php foreach($categorias as $categoria): ?>
-        <button class="board-btn" data-cat="<?= $categoria['id'] ?>">
+        <a href="panel.php?cat=<?= $categoria['id'] ?>" class="board-btn" data-cat="<?= $categoria['id'] ?>">
             <?= htmlspecialchars($categoria['nombre']) ?>
-        </button>
+        </a>
     <?php endforeach; ?>
     </div>
-    <button class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
-    <button class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button>
-    <button class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
+    <button type="button" class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
+    <button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button>
+    <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
 </div>
 
 <input type="text" class="search-input" placeholder="Buscar links...">


### PR DESCRIPTION
## Summary
- Convert board slider buttons into links to panel.php with category parameter so each board opens filtered view
- Prevent unintended form submissions by marking navigation buttons as type="button"
- Ensure board buttons style works for anchor elements

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc49750274832c9047b17b7b553802