### PR TITLE
Align favicon with first line of card titles

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -193,10 +193,9 @@ document.addEventListener('DOMContentLoaded', () => {
         <a href="editar_link.php?id=${link.id}" class="edit-btn" aria-label="Editar"><i data-feather="edit-2"></i></a>
       </div>
       <div class="card-body">
-        <div class="card-title">
-          <img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" width="20" height="20" alt="">
-          <h4>${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
-        </div>
+      <div class="card-title">
+        <h4><img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" width="20" height="20" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
+      </div>
         ${desc ? `<p>${escapeHtml(shortDesc)}</p>` : ''}
         <div class="card-actions">
           <select class="move-select" data-id="${link.id}">${categoryOptions}</select>

--- a/assets/style.css
+++ b/assets/style.css
@@ -92,9 +92,9 @@ textarea {
 .link-cards .card-image.no-image a{display:flex;}
 .link-cards .card-image.no-image img{width:32px;height:32px;}
 .link-cards .card-body {padding:10px;display:flex;flex-direction:column;}
-.link-cards .card-title {display:flex;align-items:center;gap:5px;margin-bottom:10px;}
-.link-cards .card-title img {width:20px;height:20px;}
-.link-cards .card-title h4 {margin:0;font-size:16px;display:inline;}
+.link-cards .card-title {margin-bottom:10px;overflow:hidden;}
+.link-cards .card-title h4 {margin:0;font-size:16px;}
+.link-cards .card-title h4 img {float:left;width:20px;height:20px;margin-right:5px;}
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 .link-cards .card-actions {margin-top:auto;display:flex;align-items:center;gap:5px;}
 .link-cards .card-actions .move-select {padding:4px;background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;width:fit-content;flex:0 0 auto;}

--- a/panel.php
+++ b/panel.php
@@ -198,8 +198,7 @@ include 'header.php';
                 }
             ?>
             <div class="card-title">
-                <img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" width="20" height="20" alt="">
-                <h4><?= htmlspecialchars($title) ?></h4>
+                <h4><img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" width="20" height="20" alt=""><?= htmlspecialchars($title) ?></h4>
             </div>
             <?php if(!empty($link['descripcion'])): ?>
                 <?php


### PR DESCRIPTION
## Summary
- Float card favicons inside headings so multi-line titles wrap around them
- Adjust card CSS to remove flex and align favicon to first line
- Update JS card template to embed favicon in title element

## Testing
- `npm run lint:css`
- `php -l panel.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc590e3a18832ca15b1d9da5df82b3