### PR TITLE
Refine login page layout and styling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -110,10 +110,9 @@ textarea {
 
 /* Login page */
 .login-wrapper {display:flex;gap:20px;max-width:800px;margin:0 auto;flex-wrap:wrap;min-height:calc(100vh - 80px);align-items:stretch;justify-content:center;}
-.login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);display:flex;flex-direction:column;justify-content:center;}
-.login-icon{text-align:center;margin-bottom:10px;}
-.login-icon img{height:85px;width:auto;}
-.login-icon svg{width:48px;height:48px;}
+.login-block,.social-block {flex:1 1 350px;background:#f5f8fa;color:#000;border-radius:8px;padding:20px;box-shadow:0 2px 4px rgba(0,0,0,0.1);display:flex;flex-direction:column;justify-content:center;max-height:400px;height:400px;overflow:auto;}
+.app-logo{text-align:center;margin-bottom:10px;}
+.app-logo img{height:85px;width:auto;}
 .login-form {display:flex;flex-direction:column;gap:10px;}
 .login-form input {padding:8px;}
 .login-form button {background:#1DA1F2;color:#fff;border:none;padding:10px;border-radius:4px;cursor:pointer;}

--- a/login.php
+++ b/login.php
@@ -24,10 +24,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 include 'header.php';
 ?>
-<p class="app-info">Linkaloo, ordena el caos, links a lo que te gusta</p>
+<div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
+<h1 class="app-info">Linkaloo, ordena el caos, links a lo que te gusta</h1>
 <div class="login-wrapper">
     <div class="login-block">
-        <div class="login-icon"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"><!-- Logo file already on server --></div>
         <h2>Iniciar sesión</h2>
         <?php if($error): ?><p class="error"><?= $error ?></p><?php endif; ?>
         <form method="post" class="login-form">


### PR DESCRIPTION
## Summary
- Move logo above claim and convert claim to `<h1>`
- Restrict login and social blocks to 400px height
- Add reusable `.app-logo` styles and remove unused icon rules

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc6fab5a60832cb06d012335ae1b6a