### PR TITLE
Reduce mobile gray block heights

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -112,6 +112,9 @@ textarea {
 @media (max-width:600px){
   .link-cards {column-count:2;}
   .link-cards .card {margin-bottom:10px;}
+  .link-cards .card-image.no-image{
+    height:auto;
+  }
 }
 
 /* Login page */
@@ -131,7 +134,12 @@ textarea {
 .social-btn.facebook {background:#4267B2;}
 @media (max-width:600px){
   .login-wrapper{flex-direction:column;}
-  .login-block,.social-block{width:100%;height:auto;max-height:60vh;}
+  .login-block,
+  .social-block{
+    width:100%;
+    height:auto;
+    max-height:none;
+  }
 }
 
 .login-block h2{text-align:center;}


### PR DESCRIPTION
## Summary
- let placeholder link cards resize on mobile
- allow login and social blocks to shrink to their content on small screens

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc75e24358832c8649a5501bf19353