### PR TITLE
Limit mobile block height to 280px

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -138,7 +138,7 @@ textarea {
   .social-block{
     width:100%;
     height:auto;
-    max-height:none;
+    max-height:280px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Restrict login and social blocks to a 280px max-height on small screens for better mobile layout

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc775b2c20832ca9972a5f56212b8d