### PR TITLE
Reduce spacing between claim and login blocks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -143,7 +143,7 @@ textarea {
 }
 
 .login-block h2{text-align:center;}
-.app-info{text-align:center;margin-bottom:20px;}
+.app-info{text-align:center;margin-bottom:10px;}
 
 /* Board management */
 .board-admin {margin:0 auto;}


### PR DESCRIPTION
## Summary
- Decrease margin below the claim so login/social blocks sit closer

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68bc7ba6c924832c92b4eddbc3437cdf