### PR TITLE
Limit mobile login wrapper height

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -133,7 +133,7 @@ textarea {
 .social-btn.google {background:#DB4437;}
 .social-btn.facebook {background:#4267B2;}
 @media (max-width:600px){
-  .login-wrapper{flex-direction:column;}
+  .login-wrapper{flex-direction:column;min-height:auto;max-height:600px;}
   .login-block,
   .social-block{
     width:100%;


### PR DESCRIPTION
## Summary
- Restrict `.login-wrapper` height to 600px on small screens
- Remove minimum height on mobile to let content size naturally

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc7d6e37f0832cbf302781bd17e63e