### PR TITLE
Remove login claim and adjust mobile block height

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -138,12 +138,11 @@ textarea {
   .social-block{
     width:100%;
     height:auto;
-    max-height:280px;
+    max-height:290px;
   }
 }
 
 .login-block h2{text-align:center;}
-.app-info{text-align:center;margin-bottom:10px;}
 
 /* Board management */
 .board-admin {margin:0 auto;}

--- a/login.php
+++ b/login.php
@@ -25,7 +25,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 include 'header.php';
 ?>
 <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-<h1 class="app-info">Linkaloo ordena el caos, solo links que te gustan.</h1>
 <div class="login-wrapper">
     <div class="login-block">
         <h2>Iniciar sesión</h2>


### PR DESCRIPTION
## Summary
- Remove marketing tagline from login page
- Increase mobile login/social block max height to 290px

## Testing
- `php -l login.php`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bc80597f00832c9e249b090d7d2df8