### PR TITLE
docs: add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Aplicación web simple para guardar enlaces en tableros personales. Requiere PHP
 
 ## Documentación
 
-Consulta [docs/estructura.md](docs/estructura.md) para una visión general de la arquitectura del proyecto y de la base de datos.
+Consulta [docs/estructura.md](docs/estructura.md) para una visión general de la arquitectura del proyecto y de la base de datos. Para una guía paso a paso de instalación y verificación, revisa [docs/instalacion.md](docs/instalacion.md).
 
 ## Características
 

--- a/docs/instalacion.md
+++ b/docs/instalacion.md
@@ -1,0 +1,31 @@
+# Guía de instalación
+
+Este documento describe el proceso para preparar un entorno local de desarrollo para **linkaloo**.
+
+## Requisitos
+
+- PHP 8
+- MySQL 8
+- Node.js 18
+- npm
+
+## Pasos
+
+1. Clona el repositorio en tu máquina.
+2. Crea una base de datos MySQL y ejecuta `database.sql` para generar las tablas.
+3. Ajusta las credenciales de acceso en `config.php`.
+4. Instala las dependencias de desarrollo con `npm install`.
+5. Inicia un servidor PHP en la raíz del proyecto: `php -S localhost:8000`.
+6. Abre `http://localhost:8000` en tu navegador.
+
+## Verificación
+
+Desde la raíz del proyecto puedes ejecutar las comprobaciones básicas:
+
+```bash
+php -l config.php panel.php move_link.php load_links.php
+node --check assets/main.js
+npm run lint:css
+```
+
+Si todas las órdenes finalizan sin errores, la instalación se ha realizado correctamente.


### PR DESCRIPTION
## Summary
- link README to a new installation guide with detailed setup steps
- document prerequisites and verification commands in `docs/instalacion.md`

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bdb17f1874832ca586831987c49c72