### PR TITLE
Store link images locally for each user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ favicon.ico
 img/favicon.png
 
 node_modules
+fichas/*
+!fichas/.gitkeep

--- a/image_utils.php
+++ b/image_utils.php
@@ -1,0 +1,32 @@
+<?php
+function saveImageFromUrl($url, $userId){
+    if(empty($url)){
+        return '';
+    }
+    $dir = __DIR__ . '/fichas/' . $userId;
+    if(!is_dir($dir)){
+        mkdir($dir, 0755, true);
+    }
+    $pathInfo = pathinfo(parse_url($url, PHP_URL_PATH));
+    $ext = strtolower($pathInfo['extension'] ?? 'jpg');
+    if(!in_array($ext, ['jpg','jpeg','png','gif','webp','bmp'])){
+        $ext = 'jpg';
+    }
+    $filename = uniqid('img_') . '.' . $ext;
+    $fullPath = $dir . '/' . $filename;
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; linkalooBot/1.0)',
+        CURLOPT_TIMEOUT => 5,
+    ]);
+    $data = curl_exec($ch);
+    curl_close($ch);
+    if($data){
+        file_put_contents($fullPath, $data);
+        return '/fichas/' . $userId . '/' . $filename;
+    }
+    return '';
+}
+?>

--- a/panel.php
+++ b/panel.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require_once 'image_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
@@ -109,6 +110,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                     $imagen = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
                 }
             }
+            if(!empty($imagen)){
+                $localImg = saveImageFromUrl($imagen, $user_id);
+                if($localImg){
+                    $imagen = $localImg;
+                }
+            }
             $canon = canonicalizeUrl($link_url);
             $hash = sha1($canon);
             $check = $pdo->prepare('SELECT id FROM links WHERE usuario_id = ? AND hash_url = ?');
@@ -180,7 +187,7 @@ include 'header.php';
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
         $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
-        $isDefault = empty($link['imagen']) || strpos($link['imagen'], 'google.com/s2/favicons') !== false;
+        $isDefault = empty($link['imagen']);
     ?>
     <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
         <div class="card-image <?= $isDefault ? 'no-image' : '' ?>">

--- a/tablero.php
+++ b/tablero.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require_once 'image_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
@@ -78,6 +79,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                     $newImage = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
                 }
             }
+            if(!empty($newImage)){
+                $localImg = saveImageFromUrl($newImage, $user_id);
+                if($localImg){
+                    $newImage = $localImg;
+                }
+            }
             if($newImage && $newImage !== $link['imagen']){
                 $updImg = $pdo->prepare('UPDATE links SET imagen = ? WHERE id = ? AND usuario_id = ?');
                 $updImg->execute([$newImage, $link['id'], $user_id]);
@@ -140,8 +147,8 @@ include 'header.php';
 <?php foreach($links as $link): ?>
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
-        $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
-        $isDefault = empty($link['imagen']) || strpos($link['imagen'], 'google.com/s2/favicons') !== false;
+    $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+    $isDefault = empty($link['imagen']);
     ?>
     <div class="card">
         <div class="card-image <?= $isDefault ? 'no-image' : '' ?>">


### PR DESCRIPTION
## Summary
- Save fetched link images under `/fichas/{user_id}` to avoid hotlinking
- Provide helper `saveImageFromUrl` and integrate in link creation and image refresh
- Ignore stored images in version control

## Testing
- `php -l panel.php`
- `php -l tablero.php`
- `php -l image_utils.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb52cd1bc832caf58627e29fd0826