### PR TITLE
Resize saved images to max 300px width

### DIFF
--- a/image_utils.php
+++ b/image_utils.php
@@ -23,10 +23,50 @@ function saveImageFromUrl($url, $userId){
     ]);
     $data = curl_exec($ch);
     curl_close($ch);
+
     if($data){
-        file_put_contents($fullPath, $data);
+        $img = @imagecreatefromstring($data);
+        if($img !== false){
+            $width = imagesx($img);
+            $height = imagesy($img);
+            $final = $img;
+            if($width > 300){
+                $newHeight = (int)($height * 300 / $width);
+                $resized = imagecreatetruecolor(300, $newHeight);
+                if(in_array($ext, ['png','gif','webp'])){
+                    imagecolortransparent($resized, imagecolorallocatealpha($resized, 0, 0, 0, 127));
+                    imagealphablending($resized, false);
+                    imagesavealpha($resized, true);
+                }
+                imagecopyresampled($resized, $img, 0, 0, 0, 0, 300, $newHeight, $width, $height);
+                imagedestroy($img);
+                $final = $resized;
+            }
+            imageresolution($final, 75, 75);
+            switch($ext){
+                case 'png':
+                    imagepng($final, $fullPath);
+                    break;
+                case 'gif':
+                    imagegif($final, $fullPath);
+                    break;
+                case 'webp':
+                    imagewebp($final, $fullPath);
+                    break;
+                case 'bmp':
+                    imagebmp($final, $fullPath);
+                    break;
+                default:
+                    imagejpeg($final, $fullPath, 85);
+                    break;
+            }
+            imagedestroy($final);
+        } else {
+            file_put_contents($fullPath, $data);
+        }
         return '/fichas/' . $userId . '/' . $filename;
     }
+
     return '';
 }
 ?>


### PR DESCRIPTION
## Summary
- Ensure downloaded images are resized to 300px wide if necessary
- Set output image resolution to 75dpi before saving

## Testing
- `php -l image_utils.php`
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7f60e74832cbcbfd9b5d0150991