### PR TITLE
Show favicons at original size

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -194,7 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
       <div class="card-body">
       <div class="card-title">
-        <h4><img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" width="20" height="20" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
+        <h4><img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
       </div>
         ${desc ? `<p>${escapeHtml(shortDesc)}</p>` : ''}
         <div class="card-actions">

--- a/assets/style.css
+++ b/assets/style.css
@@ -96,11 +96,11 @@ textarea {
 .link-cards .card-image .edit-btn svg{width:16px;height:16px;}
 .link-cards .card-image.no-image{display:flex;align-items:center;justify-content:center;background:#f5f8fa;height:150px;}
 .link-cards .card-image.no-image a{display:flex;}
-.link-cards .card-image.no-image img{width:32px;height:32px;}
+
 .link-cards .card-body {padding:10px;display:flex;flex-direction:column;}
 .link-cards .card-title {margin-bottom:10px;overflow:hidden;}
 .link-cards .card-title h4 {margin:0;font-size:16px;}
-.link-cards .card-title h4 img {float:left;width:20px;height:20px;margin-right:5px;}
+.link-cards .card-title h4 img {float:left;margin-right:5px;}
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 .link-cards .card-actions {margin-top:auto;display:flex;align-items:center;gap:5px;}
 .link-cards .card-actions .move-select {padding:4px;background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;width:fit-content;flex:0 0 auto;}
@@ -181,7 +181,7 @@ textarea {
 .board-detail-info{flex:1;}
 .board-detail-info .detail-header{display:flex;align-items:center;gap:10px;margin-bottom:10px;}
 .board-detail-info .link-header{display:flex;align-items:center;gap:5px;margin-bottom:5px;}
-.board-detail-info .link-header img{width:20px;height:20px;}
+
 .board-detail-info .created-at{color:#666;font-size:14px;margin:5px 0;}
 .board-detail-form label{display:block;margin-bottom:10px;}
 .board-detail-form input[type=text],.board-detail-form textarea{width:100%;padding:5px;}

--- a/editar_link.php
+++ b/editar_link.php
@@ -38,7 +38,7 @@ $domain = parse_url($link['url'], PHP_URL_HOST);
     </div>
     <div class="board-detail-info">
         <div class="link-header">
-            <img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" width="20" height="20" alt="">
+            <img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" alt="">
             <h2><?= htmlspecialchars($title) ?></h2>
         </div>
         <?php if(!empty($link['creado_en'])): ?>

--- a/panel.php
+++ b/panel.php
@@ -205,7 +205,7 @@ include 'header.php';
                 }
             ?>
             <div class="card-title">
-                <h4><img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" width="20" height="20" alt=""><?= htmlspecialchars($title) ?></h4>
+                <h4><img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" alt=""><?= htmlspecialchars($title) ?></h4>
             </div>
             <?php if(!empty($link['descripcion'])): ?>
                 <?php


### PR DESCRIPTION
## Summary
- Display favicons at their intrinsic dimensions by removing fixed width/height attributes.
- Clean up CSS rules that forced favicon sizes.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bdbbee8304832c85c64601c3d709e6