### PR TITLE
Store and serve local favicons

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -175,9 +175,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const escapeHtml = (str) => str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   const createCard = (link) => {
-    const domain = new URL(link.url).hostname;
-    const imgSrc = link.imagen ? link.imagen : 'https://www.google.com/s2/favicons?domain=' + encodeURIComponent(domain) + '&sz=128';
-    const isDefault = !link.imagen || link.imagen.includes('google.com/s2/favicons');
+    const imgSrc = link.imagen ? link.imagen : link.favicon;
+    const isDefault = !link.imagen;
     const card = document.createElement('div');
     card.className = 'card';
     card.dataset.cat = link.categoria_id;
@@ -194,7 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
       <div class="card-body">
       <div class="card-title">
-        <h4><img src="https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
+        <h4><img src="${escapeHtml(link.favicon)}" width="18" height="18" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
       </div>
         ${desc ? `<p>${escapeHtml(shortDesc)}</p>` : ''}
         <div class="card-actions">

--- a/editar_link.php
+++ b/editar_link.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require 'favicon_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
@@ -28,6 +29,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 include 'header.php';
 $title = $link['titulo'] ?: $link['url'];
 $domain = parse_url($link['url'], PHP_URL_HOST);
+$favicon = $domain ? getLocalFavicon($domain) : '';
 ?>
 <div class="board-detail">
     <div class="board-detail-image">
@@ -38,7 +40,7 @@ $domain = parse_url($link['url'], PHP_URL_HOST);
     </div>
     <div class="board-detail-info">
         <div class="link-header">
-            <img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" alt="">
+            <img src="<?= htmlspecialchars($favicon) ?>" width="18" height="18" alt="">
             <h2><?= htmlspecialchars($title) ?></h2>
         </div>
         <?php if(!empty($link['creado_en'])): ?>

--- a/favicon_utils.php
+++ b/favicon_utils.php
@@ -1,0 +1,44 @@
+<?php
+function getLocalFavicon($domain){
+    if(empty($domain)){
+        return '';
+    }
+    $base = preg_replace('/\.[^.]+$/', '', $domain);
+    $dir = __DIR__ . '/local_favicons/' . $base;
+    $path = $dir . '/favicon.png';
+    $relative = '/local_favicons/' . $base . '/favicon.png';
+    if(file_exists($path)){
+        return $relative;
+    }
+    if(!is_dir($dir)){
+        mkdir($dir, 0755, true);
+    }
+    $url = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; linkalooBot/1.0)',
+        CURLOPT_TIMEOUT => 5,
+    ]);
+    $data = curl_exec($ch);
+    curl_close($ch);
+    if($data){
+        $img = @imagecreatefromstring($data);
+        if($img){
+            $resized = imagecreatetruecolor(25, 25);
+            imagecolortransparent($resized, imagecolorallocatealpha($resized, 0, 0, 0, 127));
+            imagealphablending($resized, false);
+            imagesavealpha($resized, true);
+            $width = imagesx($img);
+            $height = imagesy($img);
+            imagecopyresampled($resized, $img, 0, 0, 0, 0, 25, 25, $width, $height);
+            imagepng($resized, $path);
+            imagedestroy($img);
+            imagedestroy($resized);
+            return $relative;
+        }
+    }
+    return $url;
+}
+?>

--- a/load_links.php
+++ b/load_links.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require 'favicon_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
     http_response_code(401);
@@ -27,6 +28,8 @@ foreach($links as &$link){
     if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 75){
         $link['descripcion'] = mb_substr($link['descripcion'], 0, 72) . '...';
     }
+    $domain = parse_url($link['url'], PHP_URL_HOST);
+    $link['favicon'] = $domain ? getLocalFavicon($domain) : '';
 }
 unset($link);
 header('Content-Type: application/json; charset=utf-8');

--- a/local_favicons/.gitignore
+++ b/local_favicons/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/panel.php
+++ b/panel.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require 'favicon_utils.php';
 require_once 'image_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
@@ -107,10 +108,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             if (empty($imagen)) {
                 $domain = parse_url($link_url, PHP_URL_HOST);
                 if ($domain) {
-                    $imagen = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+                    $imagen = getLocalFavicon($domain);
                 }
             }
-            if(!empty($imagen)){
+            if(!empty($imagen) && str_starts_with($imagen, 'http')){
                 $localImg = saveImageFromUrl($imagen, $user_id);
                 if($localImg){
                     $imagen = $localImg;
@@ -186,7 +187,8 @@ include 'header.php';
 <?php foreach($links as $index => $link): ?>
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
-        $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+        $favicon = $domain ? getLocalFavicon($domain) : '';
+        $imgSrc = !empty($link['imagen']) ? $link['imagen'] : $favicon;
         $isDefault = empty($link['imagen']);
     ?>
     <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
@@ -205,7 +207,7 @@ include 'header.php';
                 }
             ?>
             <div class="card-title">
-                <h4><img src="https://www.google.com/s2/favicons?domain=<?= urlencode($domain) ?>" alt=""><?= htmlspecialchars($title) ?></h4>
+                <h4><img src="<?= htmlspecialchars($favicon) ?>" width="18" height="18" alt=""><?= htmlspecialchars($title) ?></h4>
             </div>
             <?php if(!empty($link['descripcion'])): ?>
                 <?php

--- a/tablero.php
+++ b/tablero.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require 'favicon_utils.php';
 require_once 'image_utils.php';
 session_start();
 if(!isset($_SESSION['user_id'])){
@@ -76,10 +77,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             if(empty($newImage)){
                 $domain = parse_url($link['url'], PHP_URL_HOST);
                 if($domain){
-                    $newImage = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+                    $newImage = getLocalFavicon($domain);
                 }
             }
-            if(!empty($newImage)){
+            if(!empty($newImage) && str_starts_with($newImage, 'http')){
                 $localImg = saveImageFromUrl($newImage, $user_id);
                 if($localImg){
                     $newImage = $localImg;
@@ -147,7 +148,8 @@ include 'header.php';
 <?php foreach($links as $link): ?>
     <?php
         $domain = parse_url($link['url'], PHP_URL_HOST);
-    $imgSrc = !empty($link['imagen']) ? $link['imagen'] : 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
+    $favicon = $domain ? getLocalFavicon($domain) : '';
+    $imgSrc = !empty($link['imagen']) ? $link['imagen'] : $favicon;
     $isDefault = empty($link['imagen']);
     ?>
     <div class="card">


### PR DESCRIPTION
## Summary
- Cache favicons under `local_favicons/<domain>` and resize to 25x25 for reuse
- Serve cached favicons in link cards and edit views at 18x18
- Include favicon path in API responses for client-side rendering

## Testing
- `php -l favicon_utils.php load_links.php panel.php tablero.php editar_link.php`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bdbfe6ba0c832cb468403a2e94da47