### PR TITLE
Ajusta presentación de favicon en títulos

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -99,8 +99,8 @@ textarea {
 
 .link-cards .card-body {padding:10px;display:flex;flex-direction:column;}
 .link-cards .card-title {margin-bottom:10px;overflow:hidden;}
-.link-cards .card-title h4 {margin:0;font-size:16px;}
-.link-cards .card-title h4 img {float:left;margin-right:5px;}
+.link-cards .card-title h4 {margin:0;font-size:16px;display:flex;align-items:flex-start;}
+.link-cards .card-title h4 img {width:18px;height:18px;margin-right:5px;flex-shrink:0;}
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 .link-cards .card-actions {margin-top:auto;display:flex;align-items:center;gap:5px;}
 .link-cards .card-actions .move-select {padding:4px;background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;width:fit-content;flex:0 0 auto;}


### PR DESCRIPTION
## Summary
- Alinea el título de las fichas usando flex para que el texto rodee al favicon
- Fija el tamaño del favicon a 18x18px con margen para separar del título

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3be64e4832cbdd51836ad6ed71b