### PR TITLE
Store favicons in flat directory with domain-based filenames

### DIFF
--- a/favicon_utils.php
+++ b/favicon_utils.php
@@ -3,15 +3,16 @@ function getLocalFavicon($domain){
     if(empty($domain)){
         return '';
     }
-    $base = preg_replace('/\.[^.]+$/', '', $domain);
-    $dir = __DIR__ . '/local_favicons/' . $base;
-    $path = $dir . '/favicon.png';
-    $relative = '/local_favicons/' . $base . '/favicon.png';
-    if(file_exists($path)){
-        return $relative;
-    }
+    $base = preg_replace('/^www\./i', '', $domain);
+    $base = preg_replace('/\.[^.]+$/', '', $base);
+    $dir = __DIR__ . '/local_favicons';
     if(!is_dir($dir)){
         mkdir($dir, 0755, true);
+    }
+    $path = $dir . '/' . $base . '.png';
+    $relative = '/local_favicons/' . $base . '.png';
+    if(file_exists($path)){
+        return $relative;
     }
     $url = 'https://www.google.com/s2/favicons?domain=' . urlencode($domain) . '&sz=128';
     $ch = curl_init($url);


### PR DESCRIPTION
## Summary
- Save favicon files directly under `/local_favicons` using the domain name (without `www` or TLD) as the filename
- Ensure directory creation once and reuse cached favicon if it already exists

## Testing
- `php -l favicon_utils.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5b4240c832c8f1ee97f685fdd5f