### PR TITLE
Display local favicons at correct size

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -96,6 +96,8 @@ textarea {
 .link-cards .card-image .edit-btn svg{width:16px;height:16px;}
 .link-cards .card-image.no-image{display:flex;align-items:center;justify-content:center;background:#f5f8fa;height:150px;}
 .link-cards .card-image.no-image a{display:flex;}
+.link-cards .card-image.local-favicon{display:flex;align-items:center;justify-content:center;background:#f5f8fa;height:80px;}
+.link-cards .card-image.local-favicon img{width:25px;height:25px;}
 
 .link-cards .card-body {padding:10px;display:flex;flex-direction:column;}
 .link-cards .card-title {margin-bottom:10px;overflow:hidden;}

--- a/panel.php
+++ b/panel.php
@@ -190,9 +190,10 @@ include 'header.php';
         $favicon = $domain ? getLocalFavicon($domain) : '';
         $imgSrc = !empty($link['imagen']) ? $link['imagen'] : $favicon;
         $isDefault = empty($link['imagen']);
+        $isLocalFavicon = str_starts_with($imgSrc, '/local_favicons/');
     ?>
     <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
-        <div class="card-image <?= $isDefault ? 'no-image' : '' ?>">
+        <div class="card-image <?= $isDefault ? 'no-image' : '' ?> <?= $isLocalFavicon ? 'local-favicon' : '' ?>">
             <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
                 <img src="<?= htmlspecialchars($imgSrc) ?>" alt="">
             </a>


### PR DESCRIPTION
## Summary
- Detect local favicon images and mark the card image container
- Style local favicon cards to show a 25x25 icon and reduce card height

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd6ed3c8c832c9bbd152c2fbafe88