### PR TITLE
Mostrar todas las fichas al cargar y aplicar lazy loading

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -21,21 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const buttons = document.querySelectorAll('.board-btn');
   let cards = Array.from(document.querySelectorAll('.link-cards .card'));
   const searchInput = document.querySelector('.search-input');
-  const linkContainer = document.querySelector('.link-cards');
   const boardSlider = document.querySelector('.board-slider');
   const scrollLeft = document.querySelector('.board-scroll.left');
   const scrollRight = document.querySelector('.board-scroll.right');
-  const categoryOptions = document.querySelector('.form-link select') ? document.querySelector('.form-link select').innerHTML : '';
   let currentCat = 'all';
-  let loading = false;
-  let linkCount = cards.filter(c => !c.classList.contains('ad-card')).length;
-  const offsets = { all: linkCount };
-  cards.forEach(c => {
-    if (!c.classList.contains('ad-card')) {
-      const cat = c.dataset.cat;
-      offsets[cat] = (offsets[cat] || 0) + 1;
-    }
-  });
   const filter = (cat, query = '') => {
     cards.forEach(card => {
       const inCat = (cat === 'all' || card.dataset.cat === cat || card.classList.contains('ad-card'));
@@ -55,30 +44,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (buttons.length) {
-    const params = new URLSearchParams(window.location.search);
-    const initial = params.get('cat');
-    let activeBtn = buttons[0];
-    if (initial) {
-      const found = Array.from(buttons).find(b => b.dataset.cat === initial);
-      if (found) activeBtn = found;
-    }
-    currentCat = activeBtn.dataset.cat;
-    filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-    activeBtn.classList.add('active');
-    buttons.forEach(btn => {
-      btn.addEventListener('click', async () => {
-        buttons.forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        currentCat = btn.dataset.cat;
-        filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-        if (currentCat !== 'all' && !cards.some(c => c.dataset.cat === currentCat)) {
-          await loadMore();
+    if (buttons.length) {
+      const params = new URLSearchParams(window.location.search);
+      const initial = params.get('cat');
+      let activeBtn = buttons[0];
+      if (initial) {
+        const found = Array.from(buttons).find(b => b.dataset.cat === initial);
+        if (found) activeBtn = found;
+      }
+      currentCat = activeBtn.dataset.cat;
+      filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
+      activeBtn.classList.add('active');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          currentCat = btn.dataset.cat;
           filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-        }
+        });
       });
-    });
-  }
+    }
 
 
   document.querySelectorAll('.share-board').forEach(btn => {
@@ -126,10 +111,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }).then(res => res.json()).then(data => {
           if (data.success) {
             cardEl.dataset.cat = nuevaCat;
-            if (antiguaCat !== nuevaCat) {
-              offsets[antiguaCat] = Math.max((offsets[antiguaCat] || 1) - 1, 0);
-              offsets[nuevaCat] = (offsets[nuevaCat] || 0) + 1;
-            }
             const active = document.querySelector('.board-btn.active');
             if (active) filter(active.dataset.cat, searchInput ? searchInput.value.toLowerCase() : '');
           } else {
@@ -173,98 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const escapeHtml = (str) => str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-  const createCard = (link) => {
-    const imgSrc = link.imagen ? link.imagen : link.favicon;
-    const isDefault = !link.imagen;
-    const card = document.createElement('div');
-    card.className = 'card';
-    card.dataset.cat = link.categoria_id;
-    card.dataset.id = link.id;
-    const desc = link.descripcion ? link.descripcion : '';
-    const shortDesc = desc.length > 75 ? desc.substring(0, 72) + '...' : desc;
-    card.innerHTML = `
-      <div class="card-image ${isDefault ? 'no-image' : ''}">
-        <a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">
-          <img src="${escapeHtml(imgSrc)}" alt="">
-        </a>
-        <button class="share-btn" data-url="${escapeHtml(link.url)}" aria-label="Compartir"><i data-feather="share-2"></i></button>
-        <a href="editar_link.php?id=${link.id}" class="edit-btn" aria-label="Editar"><i data-feather="edit-2"></i></a>
-      </div>
-      <div class="card-body">
-      <div class="card-title">
-        <h4><img src="${escapeHtml(link.favicon)}" width="18" height="18" alt="">${escapeHtml(link.titulo ? link.titulo : link.url)}</h4>
-      </div>
-        ${desc ? `<p>${escapeHtml(shortDesc)}</p>` : ''}
-        <div class="card-actions">
-          <select class="move-select" data-id="${link.id}">${categoryOptions}</select>
-        </div>
-      </div>`;
-    card.querySelector('.move-select').value = link.categoria_id;
-    return card;
-  };
-
-  const createAdCard = () => {
-    const ad = document.createElement('div');
-    ad.className = 'card ad-card';
-    ad.dataset.cat = 'ad';
-    const body = document.createElement('div');
-    body.className = 'card-body';
-    const ins = document.createElement('ins');
-    ins.setAttribute('data-revive-zoneid', '52');
-    ins.setAttribute('data-revive-id', 'cabd7431fd9e40f440e6d6f0c0dc8623');
-    body.appendChild(ins);
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = '//4bes.es/adserver/www/delivery/asyncjs.php';
-    body.appendChild(script);
-    ad.appendChild(body);
-    return ad;
-  };
-
-  const loadMore = async () => {
-    if (loading) return false;
-    loading = true;
-    const off = offsets[currentCat] || 0;
-    const res = await fetch(`load_links.php?offset=${off}&cat=${currentCat}`);
-    const data = await res.json();
-    if (!data.length) {
-      loading = false;
-      return false;
-    }
-    data.forEach(link => {
-      const card = createCard(link);
-      linkContainer.appendChild(card);
-      cards.push(card);
-      attachCardEvents(card);
-      const cat = String(link.categoria_id);
-      offsets[cat] = (offsets[cat] || 0) + 1;
-      linkCount++;
-      if (linkCount % 16 === 0) {
-        const adCard = createAdCard();
-        linkContainer.appendChild(adCard);
-        cards.push(adCard);
-        attachCardEvents(adCard);
-      }
-    });
-    feather.replace();
-    offsets.all = linkCount;
-    offsets[currentCat] = off + data.length;
-    loading = false;
-    return true;
-  };
-
-  const sentinel = document.getElementById('sentinel');
-  if (sentinel && linkContainer) {
-    const observer = new IntersectionObserver(async (entries) => {
-      if (entries[0].isIntersecting && !loading) {
-        const got = await loadMore();
-        if (!got) observer.disconnect();
-        filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-      }
-    });
-    observer.observe(sentinel);
-  }
+  // Las fichas se cargan todas inicialmente; se eliminó la carga incremental.
 
   const MAX_DESC = 250;
   document.querySelectorAll('.card-body p').forEach(p => {

--- a/panel.php
+++ b/panel.php
@@ -137,7 +137,7 @@ $stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? OR
 $stmt->execute([$user_id]);
 $categorias = $stmt->fetchAll();
 
-$stmtL = $pdo->prepare("SELECT id, categoria_id, url, titulo, descripcion, imagen FROM links WHERE usuario_id = ? ORDER BY creado_en DESC LIMIT 18");
+$stmtL = $pdo->prepare("SELECT id, categoria_id, url, titulo, descripcion, imagen FROM links WHERE usuario_id = ? ORDER BY creado_en DESC");
 $stmtL->execute([$user_id]);
 $links = $stmtL->fetchAll();
 
@@ -195,7 +195,7 @@ include 'header.php';
     <div class="card" data-cat="<?= $link['categoria_id'] ?>" data-id="<?= $link['id'] ?>">
         <div class="card-image <?= $isDefault ? 'no-image' : '' ?> <?= $isLocalFavicon ? 'local-favicon' : '' ?>">
             <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
-                <img src="<?= htmlspecialchars($imgSrc) ?>" alt="">
+                <img src="<?= htmlspecialchars($imgSrc) ?>" alt="" loading="lazy">
             </a>
             <button class="share-btn" data-url="<?= htmlspecialchars($link['url']) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
             <a href="editar_link.php?id=<?= $link['id'] ?>" class="edit-btn" aria-label="Editar"><i data-feather="edit-2"></i></a>
@@ -208,7 +208,7 @@ include 'header.php';
                 }
             ?>
             <div class="card-title">
-                <h4><img src="<?= htmlspecialchars($favicon) ?>" width="18" height="18" alt=""><?= htmlspecialchars($title) ?></h4>
+                <h4><img src="<?= htmlspecialchars($favicon) ?>" width="18" height="18" alt="" loading="lazy"><?= htmlspecialchars($title) ?></h4>
             </div>
             <?php if(!empty($link['descripcion'])): ?>
                 <?php
@@ -240,7 +240,6 @@ include 'header.php';
     <?php endif; ?>
 <?php endforeach; ?>
 </div>
-<div id="sentinel"></div>
 
 </div>
 </body>

--- a/tablero.php
+++ b/tablero.php
@@ -117,7 +117,7 @@ include 'header.php';
 <div class="board-detail">
     <div class="board-detail-image">
         <?php if(!empty($board['imagen'])): ?>
-            <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>">
+            <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>" loading="lazy">
         <?php endif; ?>
     </div>
     <div class="board-detail-info">
@@ -155,7 +155,7 @@ include 'header.php';
     <div class="card">
         <div class="card-image <?= $isDefault ? 'no-image' : '' ?>">
             <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
-                <img src="<?= htmlspecialchars($imgSrc) ?>" alt="">
+                <img src="<?= htmlspecialchars($imgSrc) ?>" alt="" loading="lazy">
             </a>
         </div>
     </div>

--- a/tableros.php
+++ b/tableros.php
@@ -47,7 +47,7 @@ include 'header.php';
             <a href="panel.php?cat=<?= $board['id'] ?>" class="board-link">
                 <div class="board-thumb">
                 <?php if(!empty($board['imagen'])): ?>
-                    <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>">
+                    <img src="<?= htmlspecialchars($board['imagen']) ?>" alt="<?= htmlspecialchars($board['nombre']) ?>" loading="lazy">
                 <?php endif; ?>
                     <span class="link-count"><i data-feather="link"></i><?= $board['total'] ?></span>
                 </div>


### PR DESCRIPTION
## Summary
- Quita el límite de 18 enlaces y carga todas las fichas al abrir el panel
- Añade `loading="lazy"` a imágenes de tableros y tarjetas
- Elimina la lógica de scroll infinito en `main.js`

## Testing
- `php -l panel.php`
- `php -l tableros.php`
- `php -l tablero.php`
- `npm test` *(falla: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68bedfcce030832cb29351c7b94a9ff8