### PR TITLE
feat: show ad card after every eight links

### DIFF
--- a/panel.php
+++ b/panel.php
@@ -230,15 +230,7 @@ include 'header.php';
             </div>
         </div>
     </div>
-    <?php if(($index + 1) % 16 === 0): ?>
-    <div class="card ad-card" data-cat="ad">
-        <div class="card-body">
-            <!-- Revive Adserver Etiqueta JS asincrónica - Generated with Revive Adserver v5.5.2 -->
-            <ins data-revive-zoneid="52" data-revive-id="cabd7431fd9e40f440e6d6f0c0dc8623"></ins>
-            <script async src="//4bes.es/adserver/www/delivery/asyncjs.php"></script>
-        </div>
-    </div>
-    <?php elseif(($index + 1) % 8 === 0): ?>
+    <?php if(($index + 1) % 8 === 0): ?>
     <div class="card ad-card" data-cat="ad">
         <div class="card-body">
             <!-- Revive Adserver Etiqueta JS asincrónica - Generated with Revive Adserver v5.5.2 -->


### PR DESCRIPTION
## Summary
- insert Revive Adserver snippet as a card after every eight links

## Testing
- `php -l panel.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bee5216370832c882b1390b187ea33