### PR TITLE
Limit banner display per category

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentCat = 'all';
   const filter = (cat, query = '') => {
     cards.forEach(card => {
-      const inCat = (cat === 'all' || card.dataset.cat === cat || card.classList.contains('ad-card'));
+      const inCat = (cat === 'all' || card.dataset.cat === cat);
       const matches = card.classList.contains('ad-card') || card.textContent.toLowerCase().includes(query);
       card.style.display = (inCat && matches) ? '' : 'none';
     });


### PR DESCRIPTION
## Summary
- Compute per-category card counts and determine banner frequency
- Track cards per category in panel and only insert ads every 8 items up to the calculated limit
- Filter ads client-side by category so they only appear in the matching board

## Testing
- `php -l panel.php`
- `npm test` (fails: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68beed299054832c892d3466b9933392