### PR TITLE
Move search icon to top navigation

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -23,6 +23,7 @@ textarea {
 .top-menu .logo img {height:50px;}
 .top-menu ul {list-style:none;display:flex;margin:0;padding:0;}
 .top-menu li {position:relative;display:flex;align-items:center;}
+.top-menu .search-toggle{margin-left:0;margin-right:15px;}
 .menu-toggle {display:none;background:none;border:none;cursor:pointer;margin-right:15px;padding:0;}
 .menu-toggle span {display:block;width:25px;height:3px;background:#fff;margin:4px 0;}
 .feather {margin:0;}

--- a/header.php
+++ b/header.php
@@ -37,6 +37,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                 <li><a href="/login.php">Login</a></li>
                 <li><a href="/register.php">Registro</a></li>
             <?php endif; ?>
+            <li><button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button></li>
             <li class="settings-menu">
                 <button class="settings-toggle" aria-label="Configuración"><i data-feather="settings"></i></button>
                 <ul class="settings-submenu">

--- a/panel.php
+++ b/panel.php
@@ -179,7 +179,6 @@ include 'header.php';
     <?php endforeach; ?>
     </div>
     <button type="button" class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
-    <button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button>
     <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
 </div>
 


### PR DESCRIPTION
## Summary
- Add search toggle button to global top navigation
- Remove search button from board navigation
- Style search icon for placement in top menu

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c031044778832cb28c4b5537240179