### PR TITLE
Move add forms to top menu

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -71,6 +71,10 @@ textarea {
 .control-forms button{background:#1DA1F2;color:#fff;border:none;}
 .control-forms select{background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;}
 
+.top-menu .add-menu .control-forms{position:absolute;top:100%;right:0;background:#fff;color:#000;padding:10px;border-radius:4px;margin:0;flex-direction:column;align-items:stretch;gap:10px;z-index:1000;}
+.top-menu .add-menu .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
+
+
 .search-input{display:none;padding:5px;border:1px solid #ccc;border-radius:4px;margin-bottom:10px;width:100%;}
 .search-input.show{display:block;}
 

--- a/header.php
+++ b/header.php
@@ -37,6 +37,27 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                 <li><a href="/login.php">Login</a></li>
                 <li><a href="/register.php">Registro</a></li>
             <?php endif; ?>
+            <?php if(isset($_SESSION['user_id']) && isset($categorias)): ?>
+                <li class="add-menu">
+                    <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
+                    <div class="control-forms">
+                        <form method="post" class="form-categoria">
+                            <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
+                            <button type="submit">Crear tablero</button>
+                        </form>
+                        <form method="post" class="form-link">
+                            <input type="url" name="link_url" placeholder="URL" required>
+                            <input type="text" name="link_title" placeholder="Título" maxlength="50">
+                            <select name="categoria_id">
+                            <?php foreach($categorias as $categoria): ?>
+                                <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
+                            <?php endforeach; ?>
+                            </select>
+                            <button type="submit">Guardar link</button>
+                        </form>
+                    </div>
+                </li>
+            <?php endif; ?>
             <li><button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button></li>
             <li class="settings-menu">
                 <button class="settings-toggle" aria-label="Configuración"><i data-feather="settings"></i></button>

--- a/panel.php
+++ b/panel.php
@@ -177,27 +177,9 @@ include 'header.php';
     <?php endforeach; ?>
     </div>
     <button type="button" class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
-    <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
 </div>
 
 <input type="text" class="search-input" placeholder="Buscar links...">
-
-<div class="control-forms">
-    <form method="post" class="form-categoria">
-        <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
-        <button type="submit">Crear tablero</button>
-    </form>
-    <form method="post" class="form-link">
-        <input type="url" name="link_url" placeholder="URL" required>
-        <input type="text" name="link_title" placeholder="Título" maxlength="50">
-        <select name="categoria_id">
-        <?php foreach($categorias as $categoria): ?>
-            <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-        <?php endforeach; ?>
-        </select>
-        <button type="submit">Guardar link</button>
-    </form>
-</div>
 
 <div class="link-cards">
 <?php


### PR DESCRIPTION
## Summary
- Place add-link button and its forms inside the top navigation bar
- Remove redundant add controls from board navigation
- Style add forms as dropdown under new menu item

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`
- `php -l header.php panel.php`


------
https://chatgpt.com/codex/tasks/task_e_68c038f17084832c9c6daa54413b422f