### PR TITLE
Restaurar icono de búsqueda en la línea del slider

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -23,7 +23,7 @@ textarea {
 .top-menu .logo img {height:50px;}
 .top-menu ul {list-style:none;display:flex;margin:0;padding:0;}
 .top-menu li {position:relative;display:flex;align-items:center;}
-.top-menu .search-toggle{margin-left:0;margin-right:15px;}
+.board-nav .search-toggle{margin-left:0;}
 .menu-toggle {display:none;background:none;border:none;cursor:pointer;margin-right:15px;padding:0;}
 .menu-toggle span {display:block;width:25px;height:3px;background:#fff;margin:4px 0;}
 .feather {margin:0;}

--- a/header.php
+++ b/header.php
@@ -58,7 +58,6 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                     </div>
                 </li>
             <?php endif; ?>
-            <li><button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button></li>
             <li class="settings-menu">
                 <button class="settings-toggle" aria-label="Configuración"><i data-feather="settings"></i></button>
                 <ul class="settings-submenu">

--- a/panel.php
+++ b/panel.php
@@ -177,6 +177,7 @@ include 'header.php';
     <?php endforeach; ?>
     </div>
     <button type="button" class="board-scroll right" aria-label="Siguiente"><i data-feather="chevron-right"></i></button>
+    <button type="button" class="search-toggle" aria-label="Buscar"><i data-feather="search"></i></button>
 </div>
 
 <input type="text" class="search-input" placeholder="Buscar links...">


### PR DESCRIPTION
## Resumen
- Mover el botón de búsqueda desde el menú superior a la barra del slider para que vuelva a mostrarse allí.
- Ajustar los estilos CSS para alinear el nuevo botón de búsqueda dentro de la navegación de tableros.

## Pruebas
- `npm test` *(falla: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c03a264e78832c83a6496b9beb6d08