### PR TITLE
Integrate add button with top menu and expand submenus

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -48,7 +48,7 @@ textarea {
   }
 .content {background:#fff;color:#000;padding:20px;}
 
-.toggle-forms{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:24px;margin-left:5px;flex-shrink:0;}
+.toggle-forms{background:#1DA1F2;color:#fff;border:none;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:24px;margin-left:5px;flex-shrink:0;}
 .toggle-forms svg{width:24px;height:24px;}
 .search-toggle{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;margin-left:5px;flex-shrink:0;}
 .search-toggle svg{width:20px;height:20px;}
@@ -73,6 +73,13 @@ textarea {
 
 .top-menu .add-menu .control-forms{position:absolute;top:100%;right:0;background:#fff;color:#000;padding:10px;border-radius:4px;margin:0;flex-direction:column;align-items:stretch;gap:10px;z-index:1000;}
 .top-menu .add-menu .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
+
+@media (min-width:601px){
+  .top-menu .add-menu .control-forms,
+  .settings-menu .settings-submenu{
+    min-width:300px;
+  }
+}
 
 
 .search-input{display:none;padding:5px;border:1px solid #ccc;border-radius:4px;margin-bottom:10px;width:100%;}


### PR DESCRIPTION
## Summary
- Restyle the add (`+`) button to match the top menu with blue background and white icon
- Increase desktop submenu width for add and settings sections

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c03c26bcd8832ca6c87a21f6432426