### PR TITLE
Order categories by modification and retain slider position

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -22,6 +22,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let cards = Array.from(document.querySelectorAll('.link-cards .card'));
   const searchInput = document.querySelector('.search-input');
   const boardSlider = document.querySelector('.board-slider');
+  if (boardSlider) {
+    const savedScroll = sessionStorage.getItem('boardScroll');
+    if (savedScroll !== null) {
+      boardSlider.scrollLeft = parseInt(savedScroll, 10);
+    }
+  }
   const scrollLeft = document.querySelector('.board-scroll.left');
   const scrollRight = document.querySelector('.board-scroll.right');
   let currentCat = 'all';
@@ -57,6 +63,9 @@ document.addEventListener('DOMContentLoaded', () => {
       activeBtn.classList.add('active');
       buttons.forEach(btn => {
         btn.addEventListener('click', () => {
+          if (boardSlider) {
+            sessionStorage.setItem('boardScroll', boardSlider.scrollLeft);
+          }
           buttons.forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
           currentCat = btn.dataset.cat;

--- a/assets/style.css
+++ b/assets/style.css
@@ -96,7 +96,7 @@ textarea {
 .board-slider {display:flex;overflow-x:auto;gap:10px;padding:10px 0;flex:1;scrollbar-width:none;-ms-overflow-style:none;}
 .board-slider::-webkit-scrollbar {display:none;}
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;text-decoration:none;display:inline-block;}
-.board-btn.active {background:#0d8ddc;}
+.board-btn.active {background:#0b7ac2;}
 .link-cards {column-count:6;column-gap:15px;margin-top:20px;}
 .link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);break-inside:avoid;margin-bottom:15px;transition:transform .2s ease,box-shadow .2s ease;}
 .link-cards .card a {display:block;}

--- a/delete_link.php
+++ b/delete_link.php
@@ -8,9 +8,20 @@ if(!isset($_SESSION['user_id'])){
 }
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 if($id){
+    $sel = $pdo->prepare('SELECT categoria_id FROM links WHERE id = ? AND usuario_id = ?');
+    $sel->execute([$id, $_SESSION['user_id']]);
+    $cat = $sel->fetchColumn();
     $stmt = $pdo->prepare('DELETE FROM links WHERE id = ? AND usuario_id = ?');
     $stmt->execute([$id, $_SESSION['user_id']]);
-    echo json_encode(['success' => $stmt->rowCount() > 0]);
+    if ($stmt->rowCount() > 0) {
+        if ($cat) {
+            $upd = $pdo->prepare('UPDATE categorias SET modificado_en = NOW() WHERE id = ?');
+            $upd->execute([$cat]);
+        }
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false]);
+    }
 } else {
     echo json_encode(['success'=>false]);
 }

--- a/move_link.php
+++ b/move_link.php
@@ -9,9 +9,18 @@ if(!isset($_SESSION['user_id'])){
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 0;
 if($id && $categoria_id){
+    $sel = $pdo->prepare('SELECT categoria_id FROM links WHERE id = ? AND usuario_id = ?');
+    $sel->execute([$id, $_SESSION['user_id']]);
+    $oldCat = $sel->fetchColumn();
     $stmt = $pdo->prepare('UPDATE links SET categoria_id = ? WHERE id = ? AND usuario_id = ?');
     $stmt->execute([$categoria_id, $id, $_SESSION['user_id']]);
-    echo json_encode(['success' => $stmt->rowCount() > 0]);
+    if ($stmt->rowCount() > 0) {
+        $update = $pdo->prepare('UPDATE categorias SET modificado_en = NOW() WHERE id IN (?, ?)');
+        $update->execute([$categoria_id, $oldCat]);
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false]);
+    }
 } else {
     echo json_encode(['success' => false]);
 }

--- a/panel.php
+++ b/panel.php
@@ -128,6 +128,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             } else {
                 $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, url_canonica, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
                 $stmt->execute([$user_id, $categoria_id, $link_url, $canon, $link_title, $descripcion, $imagen, $hash]);
+                if ($stmt->rowCount()) {
+                    $upd = $pdo->prepare('UPDATE categorias SET modificado_en = NOW() WHERE id = ?');
+                    $upd->execute([$categoria_id]);
+                }
             }
         }
     }
@@ -135,7 +139,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY creado_en DESC');
+$stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY modificado_en DESC');
 $stmt->execute([$user_id]);
 $categorias = $stmt->fetchAll();
 


### PR DESCRIPTION
## Summary
- Sort category slider by last modification time and update categories when links change
- Preserve category slider scroll position after navigating between categories
- Darken active category button styling

## Testing
- `php -l panel.php`
- `php -l move_link.php`
- `php -l delete_link.php`
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c03febde18832caf4ceb0f01bcea3f