### PR TITLE
Reorder top navigation items

### DIFF
--- a/header.php
+++ b/header.php
@@ -31,32 +31,32 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">
             <?php if(isset($_SESSION['user_id'])): ?>
+                <?php if(isset($categorias)): ?>
+                    <li class="add-menu">
+                        <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
+                        <div class="control-forms">
+                            <form method="post" class="form-categoria">
+                                <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
+                                <button type="submit">Crear tablero</button>
+                            </form>
+                            <form method="post" class="form-link">
+                                <input type="url" name="link_url" placeholder="URL" required>
+                                <input type="text" name="link_title" placeholder="Título" maxlength="50">
+                                <select name="categoria_id">
+                                <?php foreach($categorias as $categoria): ?>
+                                    <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
+                                <?php endforeach; ?>
+                                </select>
+                                <button type="submit">Guardar link</button>
+                            </form>
+                        </div>
+                    </li>
+                <?php endif; ?>
                 <li><a href="/tableros.php">Tableros</a></li>
                 <li><a href="/cpanel.php"><?= htmlspecialchars($_SESSION['user_name'] ?? 'Usuario'); ?></a></li>
             <?php else: ?>
                 <li><a href="/login.php">Login</a></li>
                 <li><a href="/register.php">Registro</a></li>
-            <?php endif; ?>
-            <?php if(isset($_SESSION['user_id']) && isset($categorias)): ?>
-                <li class="add-menu">
-                    <button type="button" class="toggle-forms" aria-label="Añadir"><i data-feather="plus"></i></button>
-                    <div class="control-forms">
-                        <form method="post" class="form-categoria">
-                            <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
-                            <button type="submit">Crear tablero</button>
-                        </form>
-                        <form method="post" class="form-link">
-                            <input type="url" name="link_url" placeholder="URL" required>
-                            <input type="text" name="link_title" placeholder="Título" maxlength="50">
-                            <select name="categoria_id">
-                            <?php foreach($categorias as $categoria): ?>
-                                <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-                            <?php endforeach; ?>
-                            </select>
-                            <button type="submit">Guardar link</button>
-                        </form>
-                    </div>
-                </li>
             <?php endif; ?>
             <li class="settings-menu">
                 <button class="settings-toggle" aria-label="Configuración"><i data-feather="settings"></i></button>


### PR DESCRIPTION
## Summary
- Move add (+) menu item to the start of the top navigation
- Show Tableros and user link after the add button

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c0467ea070832cb4b94b94dec92008