### PR TITLE
Improve add-modal layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -59,7 +59,11 @@ textarea {
 .add-modal.show{display:flex;}
 .add-modal-content{background:#fff;color:#000;padding:20px;border-radius:8px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
+.add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;}
 .control-forms{display:flex;flex-direction:column;gap:10px;}
+.control-forms .form-section{display:flex;flex-direction:column;gap:10px;align-items:center;}
+.control-forms .form-section h3{text-align:center;margin:0;}
+.control-forms .form-section form{width:100%;}
 .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
 .control-forms input,
 .control-forms select,

--- a/header.php
+++ b/header.php
@@ -59,21 +59,29 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
 <div class="add-modal">
     <div class="add-modal-content">
         <button type="button" class="modal-close" aria-label="Cerrar">&times;</button>
+        <h2 class="modal-title">Guarda, organiza, comparte</h2>
         <div class="control-forms">
-            <form method="post" class="form-categoria">
-                <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
-                <button type="submit">Crear tablero</button>
-            </form>
-            <form method="post" class="form-link">
-                <input type="url" name="link_url" placeholder="URL" required>
-                <input type="text" name="link_title" placeholder="Título" maxlength="50">
-                <select name="categoria_id">
-                <?php foreach($categorias as $categoria): ?>
-                    <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-                <?php endforeach; ?>
-                </select>
-                <button type="submit">Guardar link</button>
-            </form>
+            <div class="form-section">
+                <h3>Añadir Tablero</h3>
+                <form method="post" class="form-categoria">
+                    <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
+                    <button type="submit">Crear tablero</button>
+                </form>
+            </div>
+            <div class="form-section">
+                <h3>Añadir tu favolink</h3>
+                <form method="post" class="form-link">
+                    <input type="url" name="link_url" placeholder="pega aquí el link" required>
+                    <input type="text" name="link_title" placeholder="Titulo" maxlength="50">
+                    <select name="categoria_id" required>
+                        <option value="">Tablero</option>
+                        <?php foreach($categorias as $categoria): ?>
+                            <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit">Guardar favolink</button>
+                </form>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Redesign add-modal with central heading and clearer sections for board and favolink creation
- Style modal forms with centered headings and improved layout

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68c04fa08fdc832c8b59408e69ee7c64