### PR TITLE
Modernize modal form layout and styling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -59,17 +59,17 @@ textarea {
 .add-modal.show{display:flex;}
 .add-modal-content{background:#fff;color:#000;padding:20px;border-radius:8px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
-.add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;}
+.add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
 .control-forms{display:flex;flex-direction:column;gap:10px;}
 .control-forms .form-section{display:flex;flex-direction:column;gap:10px;align-items:center;}
-.control-forms .form-section h3{text-align:center;margin:0;}
+.control-forms .form-section h3{text-align:center;margin:0;color:#6c757d;}
 .control-forms .form-section form{width:100%;}
 .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
 .control-forms input,
 .control-forms select,
-.control-forms button{padding:5px;border:1px solid #ccc;border-radius:4px;font-family:'Rambla',sans-serif;font-size:16px;}
+.control-forms button{padding:5px;border:1px solid #ccc;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;}
 .control-forms button{background:#1DA1F2;color:#fff;border:none;}
-.control-forms select{background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;}
+.control-forms select{background:#1DA1F2;color:#fff;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
 @media(min-width:601px){
   .control-forms form{flex-direction:column;align-items:stretch;}
   .control-forms form input,

--- a/header.php
+++ b/header.php
@@ -64,7 +64,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
             <div class="form-section">
                 <h3>Añadir Tablero</h3>
                 <form method="post" class="form-categoria">
-                    <input type="text" name="categoria_nombre" placeholder="Nombre del tablero">
+                    <input type="text" name="categoria_nombre" placeholder="Nombre del tablero nuevo">
                     <button type="submit">Crear tablero</button>
                 </form>
             </div>
@@ -74,7 +74,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                     <input type="url" name="link_url" placeholder="pega aquí el link" required>
                     <input type="text" name="link_title" placeholder="Titulo" maxlength="50">
                     <select name="categoria_id" required>
-                        <option value="">Tablero</option>
+                        <option value="">Elige el tablero</option>
                         <?php foreach($categorias as $categoria): ?>
                             <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
                         <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Tweak modal form placeholders to better guide users when adding boards and favolinks
- Refresh modal styles: blue main title, grey section titles, and rounded inputs/buttons

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0558569a4832cb71e54b8a3466869