### PR TITLE
Style modal inputs and add separator

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -57,7 +57,7 @@ textarea {
 @media (max-width:600px){.board-scroll{display:none;}}
 .add-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:1000;padding:10px;}
 .add-modal.show{display:flex;}
-.add-modal-content{background:#fff;color:#000;padding:20px;border-radius:8px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
+.add-modal-content{background:#fff;color:#000;padding:10px;padding-left:20px;border-radius:20px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
 .add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
 .control-forms{display:flex;flex-direction:column;gap:10px;}
@@ -67,9 +67,12 @@ textarea {
 .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
 .control-forms input,
 .control-forms select,
-.control-forms button{padding:5px;border:1px solid #ccc;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;}
+.control-forms button{padding:10px;padding-left:20px;border:1px solid #ccc;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;}
 .control-forms button{background:#1DA1F2;color:#fff;border:none;}
-.control-forms select{background:#1DA1F2;color:#fff;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
+.control-forms select{background:#ccc;color:#000;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
+.control-forms select option[value=""]{color:#6c757d;}
+
+.form-separator{border:0;border-top:1px solid #ccc;margin:10px 0;}
 @media(min-width:601px){
   .control-forms form{flex-direction:column;align-items:stretch;}
   .control-forms form input,

--- a/header.php
+++ b/header.php
@@ -67,6 +67,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                     <input type="text" name="categoria_nombre" placeholder="Nombre del tablero nuevo">
                     <button type="submit">Crear tablero</button>
                 </form>
+                <hr class="form-separator">
             </div>
             <div class="form-section">
                 <h3>Añadir tu favolink</h3>


### PR DESCRIPTION
## Summary
- Unify modal and field padding with 20px radius and left padding for consistent spacing
- Tint "Elige el tablero" select in gray with gray placeholder option
- Add gray horizontal separator beneath "Crear tablero" button

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c06928404c832ca3308617453fe92b