### PR TITLE
Add sponsored label under ad banners

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -128,6 +128,7 @@ textarea {
 .link-cards .card-body p {margin:0 0 10px;font-size:14px;}
 .link-cards .card-actions {margin-top:auto;display:flex;align-items:center;gap:5px;}
 .link-cards .card-actions .move-select {padding:4px;background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;width:fit-content;flex:0 0 auto;}
+.ad-card .ad-label{color:#6c757d;font-size:12px;text-align:left;margin-top:5px;}
 
 @media (max-width:1024px){
   .link-cards {column-count:4;}

--- a/panel.php
+++ b/panel.php
@@ -246,6 +246,7 @@ foreach ($links as $link):
             <!-- Revive Adserver Etiqueta JS asincrónica - Generated with Revive Adserver v5.5.2 -->
             <ins data-revive-zoneid="54" data-revive-id="cabd7431fd9e40f440e6d6f0c0dc8623"></ins>
             <script async src="//4bes.es/adserver/www/delivery/asyncjs.php"></script>
+            <div class="ad-label">patrocinado</div>
         </div>
     </div>
     <?php


### PR DESCRIPTION
## Summary
- Show grey "patrocinado" label beneath ad banners
- Style ad banner label for left alignment

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c073577fe8832cac880f02a913b803