### PR TITLE
Animate card loading for Pinterest-like feel

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -146,6 +146,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cards.forEach(attachCardEvents);
 
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  cards.forEach(card => observer.observe(card));
+
   const detailDelete = document.querySelector('.board-detail-image .delete-btn');
   if (detailDelete) {
     detailDelete.addEventListener('click', () => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -104,7 +104,8 @@ textarea {
 .board-btn {background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:20px;cursor:pointer;flex-shrink:0;text-decoration:none;display:inline-block;}
 .board-btn.active {background:#0b7ac2;}
 .link-cards {column-count:6;column-gap:15px;margin-top:20px;}
-.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);break-inside:avoid;margin-bottom:15px;transition:transform .2s ease,box-shadow .2s ease;}
+.link-cards .card {background:#fff;color:#000;border-radius:8px;overflow:hidden;width:100%;box-shadow:0 2px 4px rgba(0,0,0,0.1);break-inside:avoid;margin-bottom:15px;opacity:0;transform:translateY(20px);transition:opacity .3s ease,transform .2s ease,box-shadow .2s ease;}
+.link-cards .card.visible{opacity:1;transform:translateY(0);}
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-image{position:relative;}


### PR DESCRIPTION
## Summary
- Fade and slide cards into view as they enter the viewport
- Add IntersectionObserver logic to reveal cards smoothly

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c09df8ae04832cbb3b226a97a838be