### PR TITLE
chore: update Android package name

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.linkaloo">
+    package="com.android.linkaloo">
 
     <application
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Summary
- use com.android.linkaloo as package name in AndroidManifest

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c1860b2628832c966dae5b8d954e7b