### PR TITLE
chore: update digital asset link for deep linking

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -3,8 +3,10 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "com.example.linkaloo",
-      "sha256_cert_fingerprints": ["YOUR_APP_SHA256_FINGERPRINT"]
+      "package_name": "com.android.linkaloo",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_YOUR_SHA256_CERT_FINGERPRINT"
+      ]
     }
   }
 ]


### PR DESCRIPTION
## Summary
- ensure Digital Asset Links file uses the correct package name for Android deep linking

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c19350a7c0832ca8e3c042272480e5