### PR TITLE
Remove 'Añadir Tablero' text from modal

### DIFF
--- a/header.php
+++ b/header.php
@@ -63,7 +63,6 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         <h2 class="modal-title">Guarda, organiza, comparte</h2>
         <div class="control-forms">
             <div class="form-section">
-                <h3>Añadir Tablero</h3>
                 <form method="post" class="form-categoria">
                     <input type="text" name="categoria_nombre" placeholder="Nombre del tablero nuevo">
                     <button type="submit">Crear</button>


### PR DESCRIPTION
## Summary
- remove "Añadir Tablero" heading from board creation modal

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c3325c6b00832c8ae456a0cc1ae387