### PR TITLE
Extend user session expiration to one year

### DIFF
--- a/cambiar_password.php
+++ b/cambiar_password.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;

--- a/cpanel.php
+++ b/cpanel.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;

--- a/delete_link.php
+++ b/delete_link.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 header('Content-Type: application/json');
 if(!isset($_SESSION['user_id'])){
     echo json_encode(['success'=>false]);

--- a/editar_link.php
+++ b/editar_link.php
@@ -1,7 +1,7 @@
 <?php
 require 'config.php';
 require 'favicon_utils.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;

--- a/header.php
+++ b/header.php
@@ -1,8 +1,5 @@
 <?php
-// Iniciar sesión solo si no se ha hecho ya
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+require_once 'session.php';
 // Evitar caché persistente, pero permitir que el navegador recargue al volver atrás
 header('Cache-Control: no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 if(isset($_SESSION['user_id'])){
     header('Location: panel.php');
 } else {

--- a/load_links.php
+++ b/load_links.php
@@ -1,7 +1,7 @@
 <?php
 require 'config.php';
 require 'favicon_utils.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     http_response_code(401);
     exit;

--- a/login.php
+++ b/login.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once 'session.php';
 session_destroy();
+setcookie(session_name(), '', time() - 3600, '/');
 header('Location: login.php');
 exit;

--- a/move_link.php
+++ b/move_link.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 header('Content-Type: application/json');
 if(!isset($_SESSION['user_id'])){
     echo json_encode(['success' => false]);

--- a/oauth.php
+++ b/oauth.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 
 $provider = $_GET['provider'] ?? '';
 

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 
 if (!isset($_GET['code'])) {
     echo 'Código de autorización no proporcionado';

--- a/panel.php
+++ b/panel.php
@@ -2,7 +2,7 @@
 require 'config.php';
 require 'favicon_utils.php';
 require_once 'image_utils.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;

--- a/register.php
+++ b/register.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/session.php
+++ b/session.php
@@ -1,0 +1,15 @@
+<?php
+$lifetime = 365 * 24 * 60 * 60; // 365 días
+ini_set('session.gc_maxlifetime', $lifetime);
+session_set_cookie_params([
+    'lifetime' => $lifetime,
+    'path' => '/',
+    'domain' => '',
+    'secure' => !empty($_SERVER['HTTPS']),
+    'httponly' => true,
+    'samesite' => 'Lax'
+]);
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>

--- a/tablero.php
+++ b/tablero.php
@@ -2,7 +2,7 @@
 require 'config.php';
 require 'favicon_utils.php';
 require_once 'image_utils.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;

--- a/tableros.php
+++ b/tableros.php
@@ -1,6 +1,6 @@
 <?php
 require 'config.php';
-session_start();
+require_once 'session.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;


### PR DESCRIPTION
## Summary
- Centralize session initialization and set cookie lifetime to 365 days
- Replace direct `session_start()` calls with reusable session bootstrap
- Clear session cookie on logout for clean sign-out

## Testing
- `php -l session.php cambiar_password.php cpanel.php delete_link.php editar_link.php header.php index.php load_links.php login.php logout.php move_link.php oauth.php oauth2callback.php panel.php register.php tablero.php tableros.php`
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68c33779e438832cb94a0d01e8191a68