### PR TITLE
Remove wildcard MIME type and handle streams

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,19 +10,17 @@
              android:label="Guardar en Linkaloo">
              <!-- Un único enlace / texto -->
              <intent-filter>
-                 <action android:name="android.intent.action.SEND" />
-                 <category android:name="android.intent.category.DEFAULT" />
-                 <data android:mimeType="text/plain" />
-                 <data android:mimeType="*/*" />
-             </intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
 
              <!-- Varios elementos (opcional) -->
              <intent-filter>
-                 <action android:name="android.intent.action.SEND_MULTIPLE" />
-                 <category android:name="android.intent.category.DEFAULT" />
-                 <data android:mimeType="text/plain" />
-                 <data android:mimeType="*/*" />
-             </intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
 
              <!-- Abrir enlaces directamente -->
              <intent-filter android:autoVerify="true">

--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -12,9 +12,15 @@ class ShareReceiverActivity : AppCompatActivity() {
 
         when (intent?.action) {
             Intent.ACTION_SEND -> {
-                if ("text/plain" == intent.type) {
-                    val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
-                    sharedText?.let { handleLink(it) }
+                when (intent.type) {
+                    "text/plain" -> {
+                        val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
+                        sharedText?.let { handleLink(it) }
+                    }
+                    else -> {
+                        val stream = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+                        stream?.toString()?.let { handleLink(it) }
+                    }
                 }
             }
             Intent.ACTION_VIEW -> {
@@ -22,7 +28,13 @@ class ShareReceiverActivity : AppCompatActivity() {
                 data?.toString()?.let { handleLink(it) }
             }
             Intent.ACTION_SEND_MULTIPLE -> {
-                // Manejo de múltiples elementos si lo necesitas
+                if ("text/plain" == intent.type) {
+                    val texts = intent.getStringArrayListExtra(Intent.EXTRA_TEXT)
+                    texts?.forEach { handleLink(it) }
+                } else {
+                    val streams = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+                    streams?.forEach { handleLink(it.toString()) }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- limit ACTION_SEND filters to text/plain by removing wildcard mime type
- support shared file streams and multiple items in ShareReceiverActivity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c3406a4724832c8c2bf0dc82efb2a4