### PR TITLE
Remove unused multi-share intent handling

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,18 +15,11 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
-             <!-- Varios elementos (opcional) -->
-             <intent-filter>
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
+            <!-- Abrir enlaces directamente -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
-
-             <!-- Abrir enlaces directamente -->
-             <intent-filter android:autoVerify="true">
-                 <action android:name="android.intent.action.VIEW" />
-                 <category android:name="android.intent.category.DEFAULT" />
-                 <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.BROWSABLE" />
                  <data android:scheme="https" android:host="linkaloo.com" />
                  <data android:scheme="http" android:host="linkaloo.com" />
              </intent-filter>

--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -27,15 +27,6 @@ class ShareReceiverActivity : AppCompatActivity() {
                 val data: Uri? = intent.data
                 data?.toString()?.let { handleLink(it) }
             }
-            Intent.ACTION_SEND_MULTIPLE -> {
-                if ("text/plain" == intent.type) {
-                    val texts = intent.getStringArrayListExtra(Intent.EXTRA_TEXT)
-                    texts?.forEach { handleLink(it) }
-                } else {
-                    val streams = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
-                    streams?.forEach { handleLink(it.toString()) }
-                }
-            }
         }
 
         // Redirige a tu Main si procede o muestra una UI ligera


### PR DESCRIPTION
## Summary
- drop SEND_MULTIPLE intent filter from the manifest
- remove dead code for multi-item shares

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c341926030832c87aaaa83b1a84e64