### PR TITLE
Add public sharing toggle for tableros

### DIFF
--- a/tablero_publico.php
+++ b/tablero_publico.php
@@ -1,0 +1,82 @@
+<?php
+require 'config.php';
+require 'favicon_utils.php';
+require_once 'image_utils.php';
+require_once 'session.php';
+
+$token = $_GET['token'] ?? '';
+if(!$token){
+    http_response_code(404);
+    exit('Tablero no disponible');
+}
+
+$stmt = $pdo->prepare('SELECT id, nombre, nota FROM categorias WHERE share_token = ?');
+$stmt->execute([$token]);
+$board = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$board){
+    http_response_code(404);
+    exit('Tablero no disponible');
+}
+
+$linksStmt = $pdo->prepare('SELECT url, titulo, descripcion, imagen FROM links WHERE categoria_id = ? ORDER BY id DESC');
+$linksStmt->execute([$board['id']]);
+$links = $linksStmt->fetchAll();
+
+$baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
+$shareUrl = $baseUrl . '/tablero_publico.php?token=' . $token;
+
+include 'header.php';
+?>
+<div class="board-detail">
+    <div class="board-detail-info">
+        <div class="detail-header">
+            <h2><?= htmlspecialchars($board['nombre']) ?></h2>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($shareUrl) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
+        </div>
+        <?php if(!empty($board['nota'])): ?>
+        <p><?= htmlspecialchars($board['nota']) ?></p>
+        <?php endif; ?>
+    </div>
+</div>
+<?php if(!empty($links)): ?>
+<div class="link-cards board-links">
+<?php foreach($links as $link): ?>
+    <?php
+        $domain = parse_url($link['url'], PHP_URL_HOST);
+        $favicon = $domain ? getLocalFavicon($domain) : '';
+        $imgSrc = !empty($link['imagen']) ? $link['imagen'] : $favicon;
+        $isDefault = empty($link['imagen']);
+        $isLocalFavicon = str_starts_with($imgSrc, '/local_favicons/');
+        $title = $link['titulo'] ?: $link['url'];
+        if (mb_strlen($title) > 50) {
+            $title = mb_substr($title, 0, 47) . '...';
+        }
+        $desc = $link['descripcion'] ?? '';
+        if (mb_strlen($desc) > 75) {
+            $desc = mb_substr($desc, 0, 72) . '...';
+        }
+    ?>
+    <div class="card">
+        <div class="card-image <?= $isDefault ? 'no-image' : '' ?> <?= $isLocalFavicon ? 'local-favicon' : '' ?>">
+            <a href="<?= htmlspecialchars($link['url']) ?>" target="_blank" rel="noopener noreferrer">
+                <img src="<?= htmlspecialchars($imgSrc) ?>" alt="" loading="lazy">
+            </a>
+            <button class="share-btn" data-url="<?= htmlspecialchars($link['url']) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
+        </div>
+        <div class="card-body">
+            <div class="card-title">
+                <h4><img src="<?= htmlspecialchars($favicon) ?>" width="18" height="18" alt="" loading="lazy"><?= htmlspecialchars($title) ?></h4>
+            </div>
+            <?php if(!empty($desc)): ?>
+            <p><?= htmlspecialchars($desc) ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+<?php endforeach; ?>
+</div>
+<?php else: ?>
+<p>No hay links en este tablero.</p>
+<?php endif; ?>
+</div>
+</body>
+</html>

--- a/tableros.php
+++ b/tableros.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-$stmt = $pdo->prepare('SELECT c.id, c.nombre,
+$stmt = $pdo->prepare('SELECT c.id, c.nombre, c.share_token,
                               COUNT(l.id) AS total,
                               (SELECT l2.imagen FROM links l2
                                WHERE l2.categoria_id = c.id AND l2.usuario_id = ?
@@ -26,7 +26,7 @@ $stmt = $pdo->prepare('SELECT c.id, c.nombre,
                          FROM categorias c
                          LEFT JOIN links l ON l.categoria_id = c.id AND l.usuario_id = ?
                          WHERE c.usuario_id = ?
-                         GROUP BY c.id, c.nombre
+                         GROUP BY c.id, c.nombre, c.share_token
                          ORDER BY c.creado_en DESC');
 $stmt->execute([$user_id, $user_id, $user_id]);
 $boards = $stmt->fetchAll();
@@ -53,9 +53,11 @@ include 'header.php';
                 </div>
                 <span class="board-name"><?= htmlspecialchars($board['nombre']) ?></span>
             </a>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/panel.php?cat=' . $board['id']) ?>" aria-label="Compartir">
+            <?php if(!empty($board['share_token'])): ?>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/tablero_publico.php?token=' . $board['share_token']) ?>" aria-label="Compartir">
                 <i data-feather="share-2"></i>
             </button>
+            <?php endif; ?>
             <a href="tablero.php?id=<?= $board['id'] ?>" class="edit-board" aria-label="Editar">
                 <i data-feather="edit-2"></i>
             </a>


### PR DESCRIPTION
## Summary
- Allow marking a board as public with a share token and toggle in board settings
- Show share button only for public boards and expose share URL
- Add public board view page accessible via share token

## Testing
- `php -l tablero.php`
- `php -l tableros.php`
- `php -l tablero_publico.php`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c44f7e6698832cb2f4157a8c9cd908