### PR TITLE
feat: include board metadata in shares

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -77,11 +77,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.querySelectorAll('.share-board').forEach(btn => {
     btn.addEventListener('click', async () => {
-      const url = btn.dataset.url;
+      const { url, title, image } = btn.dataset;
       if (navigator.share) {
-        try { await navigator.share({ url }); } catch (_) {}
+        const shareData = { url };
+        if (title) shareData.title = title;
+        if (image && navigator.canShare) {
+          try {
+            const resp = await fetch(image);
+            const blob = await resp.blob();
+            const name = image.split('/').pop().split('?')[0] || 'image';
+            const file = new File([blob], name, { type: blob.type });
+            if (navigator.canShare({ files: [file] })) {
+              shareData.files = [file];
+            }
+          } catch (_) {}
+        }
+        try { await navigator.share(shareData); } catch (_) {}
       } else {
-        const shareUrl = 'https://www.addtoany.com/share#url=' + encodeURIComponent(url);
+        let shareUrl = 'https://www.addtoany.com/share#url=' + encodeURIComponent(url);
+        if (title) shareUrl += '&title=' + encodeURIComponent(title);
         window.open(shareUrl, '_blank', 'noopener');
       }
     });

--- a/tablero.php
+++ b/tablero.php
@@ -119,6 +119,10 @@ $modificado = $board['modificado_en'] ? date('Y-m', strtotime($board['modificado
 
 $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 $publicUrl = !empty($board['share_token']) ? $baseUrl . '/tablero_publico.php?token=' . $board['share_token'] : '';
+$shareImg = $board['imagen'] ?? '';
+if (!empty($shareImg) && !preg_match('#^https?://#', $shareImg)) {
+    $shareImg = $baseUrl . '/' . ltrim($shareImg, '/');
+}
 
 include 'header.php';
 ?>
@@ -132,7 +136,7 @@ include 'header.php';
         <div class="detail-header">
             <h2><?= htmlspecialchars($board['nombre']) ?></h2>
             <?php if(!empty($board['share_token'])): ?>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($publicUrl) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($publicUrl) ?>" data-title="<?= htmlspecialchars($board['nombre']) ?>" <?= !empty($shareImg) ? 'data-image="' . htmlspecialchars($shareImg) . '"' : '' ?> aria-label="Compartir"><i data-feather="share-2"></i></button>
             <?php endif; ?>
         </div>
         <form method="post" class="board-detail-form">

--- a/tablero_publico.php
+++ b/tablero_publico.php
@@ -10,7 +10,7 @@ if(!$token){
     exit('Tablero no disponible');
 }
 
-$stmt = $pdo->prepare('SELECT id, nombre, nota FROM categorias WHERE share_token = ?');
+$stmt = $pdo->prepare('SELECT c.id, c.nombre, c.nota, (SELECT l2.imagen FROM links l2 WHERE l2.categoria_id = c.id ORDER BY l2.id LIMIT 1) AS imagen FROM categorias c WHERE share_token = ?');
 $stmt->execute([$token]);
 $board = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$board){
@@ -24,6 +24,10 @@ $links = $linksStmt->fetchAll();
 
 $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 $shareUrl = $baseUrl . '/tablero_publico.php?token=' . $token;
+$shareImg = $board['imagen'] ?? '';
+if (!empty($shareImg) && !preg_match('#^https?://#', $shareImg)) {
+    $shareImg = $baseUrl . '/' . ltrim($shareImg, '/');
+}
 
 include 'header.php';
 ?>
@@ -31,7 +35,7 @@ include 'header.php';
     <div class="board-detail-info">
         <div class="detail-header">
             <h2><?= htmlspecialchars($board['nombre']) ?></h2>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($shareUrl) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($shareUrl) ?>" data-title="<?= htmlspecialchars($board['nombre']) ?>" <?= !empty($shareImg) ? 'data-image="' . htmlspecialchars($shareImg) . '"' : '' ?> aria-label="Compartir"><i data-feather="share-2"></i></button>
         </div>
         <?php if(!empty($board['nota'])): ?>
         <p><?= htmlspecialchars($board['nota']) ?></p>

--- a/tableros.php
+++ b/tableros.php
@@ -53,8 +53,14 @@ include 'header.php';
                 </div>
                 <span class="board-name"><?= htmlspecialchars($board['nombre']) ?></span>
             </a>
-            <?php if(!empty($board['share_token'])): ?>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/tablero_publico.php?token=' . $board['share_token']) ?>" aria-label="Compartir">
+            <?php if(!empty($board['share_token'])):
+                $shareUrl = $baseUrl . '/tablero_publico.php?token=' . $board['share_token'];
+                $shareImg = $board['imagen'];
+                if (!empty($shareImg) && !preg_match('#^https?://#', $shareImg)) {
+                    $shareImg = $baseUrl . '/' . ltrim($shareImg, '/');
+                }
+            ?>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($shareUrl) ?>" data-title="<?= htmlspecialchars($board['nombre']) ?>" <?= !empty($shareImg) ? 'data-image="' . htmlspecialchars($shareImg) . '"' : '' ?> aria-label="Compartir">
                 <i data-feather="share-2"></i>
             </button>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- share boards along with their title and image
- send complete board details when using Web Share API

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c45b6dc954832c99b5028734c668f3