### PR TITLE
Style board image and align action buttons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -201,7 +201,7 @@ textarea {
 
 /* Board detail */
 .board-detail {display:flex;max-width:800px;margin:20px auto;gap:20px;}
-.board-detail-image{flex:1;aspect-ratio:1;overflow:hidden;position:relative;}
+.board-detail-image{flex:1;aspect-ratio:1;overflow:hidden;position:relative;border-radius:20px;}
 .board-detail-image img{width:100%;height:100%;object-fit:cover;display:block;}
 .board-detail-image .delete-btn{position:absolute;bottom:10px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;}
 .board-detail-image .delete-btn svg{width:16px;height:16px;}
@@ -213,7 +213,8 @@ textarea {
 .board-detail-form input[type=text],.board-detail-form textarea{width:100%;padding:5px;}
 .board-detail-form textarea{min-height:80px;}
 .board-detail-form p{margin:5px 0;}
-.board-detail-form button,
+.board-form-buttons{display:flex;gap:10px;flex-wrap:wrap;}
+.board-detail-form button{padding:10px 20px;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;background:#1DA1F2;color:#fff;border:none;text-align:center;cursor:pointer;}
 .links-link{background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:4px;cursor:pointer;text-decoration:none;display:inline-block;text-align:center;}
 @media (max-width:600px){
   .board-detail{flex-direction:column;}

--- a/tablero.php
+++ b/tablero.php
@@ -152,15 +152,15 @@ include 'header.php';
             <p>Links guardados: <a class="links-link" href="panel.php?cat=<?= $id ?>"><?= $board['total_links'] ?></a></p>
             <p>Creado: <?= htmlspecialchars($creado) ?></p>
             <p>Modificado: <?= htmlspecialchars($modificado) ?></p>
-            <button type="submit">Guardar</button>
-            <button type="submit" name="delete_board" onclick="return confirm('¿Eliminar este tablero?');">Eliminar tablero</button>
+            <div class="board-form-buttons">
+                <button type="submit" name="update_images">Actualizar imágenes</button>
+                <button type="submit">Guardar</button>
+                <button type="submit" name="delete_board" onclick="return confirm('¿Eliminar este tablero?');">Eliminar tablero</button>
+            </div>
         </form>
     </div>
 </div>
 <?php if(!empty($links)): ?>
-<form method="post" class="update-images-form">
-    <button type="submit" name="update_images">Actualizar imágenes</button>
-</form>
 <div class="link-cards board-links">
 <?php foreach($links as $link): ?>
     <?php


### PR DESCRIPTION
## Summary
- Round board image corners
- Display update, save, and delete buttons in a single row with modal styling

## Testing
- ⚠️ `npm test` (no test specified)
- ✅ `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c4759416e4832c88cd440826ffa099