### PR TITLE
Add share icon next to public board sharing option

### DIFF
--- a/tablero.php
+++ b/tablero.php
@@ -147,7 +147,8 @@ include 'header.php';
                 <textarea name="nota"><?= htmlspecialchars($board['nota'] ?? '') ?></textarea>
             </label>
             <label>
-                <input type="checkbox" name="publico" value="1" <?= !empty($board['share_token']) ? 'checked' : '' ?>> Compartir tablero públicamente
+                <input type="checkbox" name="publico" value="1" <?= !empty($board['share_token']) ? 'checked' : '' ?>>
+                Compartir tablero públicamente <i data-feather="share-2"></i>
             </label>
             <p>Links guardados: <a class="links-link" href="panel.php?cat=<?= $id ?>"><?= $board['total_links'] ?></a></p>
             <p>Creado: <?= htmlspecialchars($creado) ?></p>


### PR DESCRIPTION
## Summary
- add Feather share icon next to “Compartir tablero públicamente” option on board detail

## Testing
- `php -l tablero.php`
- `npm test` *(fails: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c476ffcf2c832c855ddbc7577f55ce