### PR TITLE
Style share icon in board settings

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -213,6 +213,9 @@ textarea {
 .board-detail-form input[type=text],.board-detail-form textarea{width:100%;padding:5px;}
 .board-detail-form textarea{min-height:80px;}
 .board-detail-form p{margin:5px 0;}
+.board-detail-form .share-checkbox{display:flex;align-items:center;gap:5px;margin-bottom:10px;}
+.board-detail-form .share-icon{color:#1DA1F2;display:flex;align-items:center;}
+.board-detail-form .share-icon svg{width:16px;height:16px;}
 .board-form-buttons{display:flex;gap:10px;flex-wrap:wrap;}
 .board-detail-form button{padding:10px 20px;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;background:#1DA1F2;color:#fff;border:none;text-align:center;cursor:pointer;}
 .links-link{background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:4px;cursor:pointer;text-decoration:none;display:inline-block;text-align:center;}

--- a/tablero.php
+++ b/tablero.php
@@ -146,10 +146,13 @@ include 'header.php';
             <label>Nota<br>
                 <textarea name="nota"><?= htmlspecialchars($board['nota'] ?? '') ?></textarea>
             </label>
-            <label>
-                <input type="checkbox" name="publico" value="1" <?= !empty($board['share_token']) ? 'checked' : '' ?>>
-                Compartir tablero públicamente <i data-feather="share-2"></i>
-            </label>
+            <div class="share-checkbox">
+                <label>
+                    <input type="checkbox" name="publico" value="1" <?= !empty($board['share_token']) ? 'checked' : '' ?>>
+                    Compartir tablero públicamente
+                </label>
+                <div class="share-icon"><i data-feather="share-2"></i></div>
+            </div>
             <p>Links guardados: <a class="links-link" href="panel.php?cat=<?= $id ?>"><?= $board['total_links'] ?></a></p>
             <p>Creado: <?= htmlspecialchars($creado) ?></p>
             <p>Modificado: <?= htmlspecialchars($modificado) ?></p>


### PR DESCRIPTION
## Summary
- Style public board share icon in blue and small size
- Separate share icon from checkbox to avoid unwanted toggle

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c478ea1f70832cb2358aa7e0963f07