### PR TITLE
Move share button beside board public sharing option

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -214,8 +214,6 @@ textarea {
 .board-detail-form textarea{min-height:80px;}
 .board-detail-form p{margin:5px 0;}
 .board-detail-form .share-checkbox{display:flex;align-items:center;gap:5px;margin-bottom:10px;}
-.board-detail-form .share-icon{color:#1DA1F2;display:flex;align-items:center;}
-.board-detail-form .share-icon svg{width:16px;height:16px;}
 .board-form-buttons{display:flex;gap:10px;flex-wrap:wrap;}
 .board-detail-form button{padding:10px 20px;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;background:#1DA1F2;color:#fff;border:none;text-align:center;cursor:pointer;}
 .links-link{background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:4px;cursor:pointer;text-decoration:none;display:inline-block;text-align:center;}

--- a/tablero.php
+++ b/tablero.php
@@ -135,9 +135,6 @@ include 'header.php';
     <div class="board-detail-info">
         <div class="detail-header">
             <h2><?= htmlspecialchars($board['nombre']) ?></h2>
-            <?php if(!empty($board['share_token'])): ?>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($publicUrl) ?>" data-title="<?= htmlspecialchars($board['nombre']) ?>" <?= !empty($shareImg) ? 'data-image="' . htmlspecialchars($shareImg) . '"' : '' ?> aria-label="Compartir"><i data-feather="share-2"></i></button>
-            <?php endif; ?>
         </div>
         <form method="post" class="board-detail-form">
             <label>Nombre<br>
@@ -151,7 +148,9 @@ include 'header.php';
                     <input type="checkbox" name="publico" value="1" <?= !empty($board['share_token']) ? 'checked' : '' ?>>
                     Compartir tablero públicamente
                 </label>
-                <div class="share-icon"><i data-feather="share-2"></i></div>
+                <?php if(!empty($board['share_token'])): ?>
+                <button type="button" class="share-board" data-url="<?= htmlspecialchars($publicUrl) ?>" data-title="<?= htmlspecialchars($board['nombre']) ?>" <?= !empty($shareImg) ? 'data-image="' . htmlspecialchars($shareImg) . '"' : '' ?> aria-label="Compartir"><i data-feather="share-2"></i></button>
+                <?php endif; ?>
             </div>
             <p>Links guardados: <a class="links-link" href="panel.php?cat=<?= $id ?>"><?= $board['total_links'] ?></a></p>
             <p>Creado: <?= htmlspecialchars($creado) ?></p>


### PR DESCRIPTION
## Summary
- Remove extra share icon beside "Compartir tablero públicamente" checkbox.
- Relocate functional share button next to that checkbox and drop header button.
- Clean up unused `.share-icon` CSS rules.

## Testing
- `php -l tablero.php`
- `npm run lint:css`
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_68c47ae9ebb8832c9e7cd46da12da4c9