### PR TITLE
feat: add label and style for public board sharing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -183,9 +183,10 @@ textarea {
 .board-link .link-count {position:absolute;bottom:5px;right:5px;background:#fff;color:#1DA1F2;border-radius:4px;padding:2px 4px;display:flex;align-items:center;gap:3px;font-size:12px;}
 .board-link .link-count svg{width:16px;height:16px;}
 .board-name {display:block;font-weight:bold;margin-top:5px;color:#1DA1F2;}
-.share-board{background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+.share-board{background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;gap:4px;}
 .share-board svg{width:16px;height:16px;}
 .board-item .share-board{position:absolute;top:20px;right:20px;z-index:1;}
+.detail-header .share-board{padding:5px 10px;}
 .board-item .edit-board{position:absolute;top:55px;right:20px;text-decoration:none;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;z-index:1;}
 .board-item .edit-board svg{width:16px;height:16px;}
 

--- a/tablero.php
+++ b/tablero.php
@@ -123,7 +123,10 @@ include 'header.php';
     <div class="board-detail-info">
         <div class="detail-header">
             <h2><?= htmlspecialchars($board['nombre']) ?></h2>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/panel.php?cat=' . $id) ?>" aria-label="Compartir"><i data-feather="share-2"></i></button>
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/panel.php?cat=' . $id) ?>" aria-label="Compartir tablero públicamente">
+                <i data-feather="share-2"></i>
+                <span>Compartir tablero públicamente</span>
+            </button>
         </div>
         <form method="post" class="board-detail-form">
             <label>Nombre<br>

--- a/tableros.php
+++ b/tableros.php
@@ -53,7 +53,7 @@ include 'header.php';
                 </div>
                 <span class="board-name"><?= htmlspecialchars($board['nombre']) ?></span>
             </a>
-            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/panel.php?cat=' . $board['id']) ?>" aria-label="Compartir">
+            <button type="button" class="share-board" data-url="<?= htmlspecialchars($baseUrl . '/panel.php?cat=' . $board['id']) ?>" aria-label="Compartir tablero públicamente">
                 <i data-feather="share-2"></i>
             </button>
             <a href="tablero.php?id=<?= $board['id'] ?>" class="edit-board" aria-label="Editar">


### PR DESCRIPTION
## Summary
- add text label "Compartir tablero públicamente" to board share button
- align share icon with label and keep blue-on-white styling
- update share button aria-label for board list

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c47fcd0800832c8e7c4a5a5a57505d