### PR TITLE
Improve share button styling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -110,8 +110,8 @@ textarea {
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-image{position:relative;}
-.link-cards .card-image .share-btn{position:absolute;top:10px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;cursor:pointer;}
-.link-cards .card-image .share-btn svg{width:16px;height:16px;}
+.link-cards .card-image .share-btn{position:absolute;top:10px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:8px;cursor:pointer;}
+.link-cards .card-image .share-btn svg{width:20px;height:20px;stroke:currentcolor;}
 .link-cards .card-image .edit-btn{position:absolute;top:40px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;}
 .link-cards .card-image .edit-btn svg{width:16px;height:16px;}
 .link-cards .card-image.no-image{display:flex;align-items:center;justify-content:center;background:#f5f8fa;height:150px;}
@@ -184,8 +184,8 @@ textarea {
 .board-link .link-count {position:absolute;bottom:5px;right:5px;background:#fff;color:#1DA1F2;border-radius:4px;padding:2px 4px;display:flex;align-items:center;gap:3px;font-size:12px;}
 .board-link .link-count svg{width:16px;height:16px;}
 .board-name {display:block;font-weight:bold;margin-top:5px;color:#1DA1F2;}
-.share-board{background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
-.share-board svg{width:16px;height:16px;stroke:currentcolor;}
+.share-board{background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:8px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+.share-board svg{width:20px;height:20px;stroke:currentcolor;}
 .board-item .share-board{position:absolute;top:20px;right:20px;z-index:1;}
 .board-item .edit-board{position:absolute;top:55px;right:20px;text-decoration:none;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;z-index:1;}
 .board-item .edit-board svg{width:16px;height:16px;}


### PR DESCRIPTION
## Summary
- enlarge share button icons and padding
- ensure white background and blue icon color

## Testing
- `npm run lint:css`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c483bc37cc832cbd57ecd3eef626f3