### PR TITLE
Match share icon style with edit icon

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -110,8 +110,8 @@ textarea {
 .link-cards .card a {display:block;}
 .link-cards .card img {width:100%;height:auto;display:block;}
 .link-cards .card-image{position:relative;}
-.link-cards .card-image .share-btn{position:absolute;top:10px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:8px;cursor:pointer;}
-.link-cards .card-image .share-btn svg{width:20px;height:20px;stroke:currentcolor;}
+.link-cards .card-image .share-btn{position:absolute;top:10px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+.link-cards .card-image .share-btn svg{width:16px;height:16px;}
 .link-cards .card-image .edit-btn{position:absolute;top:40px;right:10px;z-index:1;background:#fff;color:#1DA1F2;border:none;border-radius:4px;padding:5px;display:flex;align-items:center;justify-content:center;}
 .link-cards .card-image .edit-btn svg{width:16px;height:16px;}
 .link-cards .card-image.no-image{display:flex;align-items:center;justify-content:center;background:#f5f8fa;height:150px;}


### PR DESCRIPTION
## Summary
- Adjust share button styling in panel cards to match edit icon

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c48763d614832c971eaa4e42812766