### PR TITLE
Reduce mobile spacing for board action icons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -197,6 +197,8 @@ textarea {
 @media (max-width:600px){
   .board-grid {grid-template-columns:repeat(2,1fr);}
   .board-item {padding:5px;}
+  .board-item .share-board{top:10px;right:10px;}
+  .board-item .edit-board{top:45px;right:10px;}
 }
 
 /* Board detail */


### PR DESCRIPTION
## Summary
- Decrease top/right offsets of share and edit icons on board thumbnails for mobile view

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c48d5d4df0832ca380d110d7d6ef0f