### PR TITLE
Add API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Aplicación web simple para guardar enlaces en tableros personales. Requiere PHP
 
 ## Documentación
 
-Consulta [docs/estructura.md](docs/estructura.md) para una visión general de la arquitectura del proyecto y de la base de datos. Para una guía paso a paso de instalación y verificación, revisa [docs/instalacion.md](docs/instalacion.md).
+Consulta [docs/estructura.md](docs/estructura.md) para una visión general de la arquitectura del proyecto y de la base de datos.
+Para una guía paso a paso de instalación y verificación, revisa [docs/instalacion.md](docs/instalacion.md).
+Para los endpoints de backend disponibles, consulta [docs/api.md](docs/api.md).
 
 ## Características
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,43 @@
+# Referencia de API
+
+Este documento describe los endpoints de backend usados por la aplicación.
+Todas las rutas requieren una sesión activa del usuario.
+
+## `GET load_links.php`
+
+Devuelve enlaces del usuario en formato JSON.
+
+**Parámetros de consulta**
+
+- `offset` (opcional, entero): desplazamiento para paginación. Valor por defecto 0.
+- `cat` (opcional, entero o `all`): identificador del tablero a filtrar. Por defecto `all`.
+
+**Respuesta**
+
+Arreglo JSON con objetos que incluyen `id`, `categoria_id`, `url`, `titulo`, `descripcion`, `imagen` y `favicon`.
+
+## `POST move_link.php`
+
+Mueve un enlace a otro tablero.
+
+**Campos del cuerpo**
+
+- `id` (entero): identificador del enlace.
+- `categoria_id` (entero): identificador del tablero destino.
+
+**Respuesta**
+
+Objeto JSON `{ "success": true|false }`.
+
+## `POST delete_link.php`
+
+Elimina un enlace del usuario.
+
+**Campos del cuerpo**
+
+- `id` (entero): identificador del enlace.
+
+**Respuesta**
+
+Objeto JSON `{ "success": true|false }`.
+


### PR DESCRIPTION
## Summary
- document backend endpoints in `docs/api.md`
- link new API reference from README

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68c5a0533b90832c97843e4c62664445