### PR TITLE
Improve metadata scraping headers

### DIFF
--- a/panel.php
+++ b/panel.php
@@ -41,10 +41,13 @@ function scrapeMetadata($url){
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
-        CURLOPT_TIMEOUT => 5,
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_ENCODING => '',
+        CURLOPT_REFERER => 'https://www.google.com/',
         CURLOPT_HTTPHEADER => [
             'Accept-Language: es-ES,es;q=0.9,en;q=0.8',
-            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Encoding: gzip, deflate, br'
         ],
     ]);
     $html = curl_exec($ch);


### PR DESCRIPTION
## Summary
- handle gzipped/deflated pages while scraping metadata
- send a referer and broader headers for better compatibility

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68c5ad0c0e54832ca6de97f293854703