### PR TITLE
Limit card description length to 45 characters

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Las fichas se cargan todas inicialmente; se eliminó la carga incremental.
 
-  const MAX_DESC = 250;
+  const MAX_DESC = 45;
   document.querySelectorAll('.card-body p').forEach(p => {
     const text = p.textContent.trim();
     if (text.length > MAX_DESC) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -127,7 +127,7 @@ textarea {
 .link-cards .card-title {margin-bottom:10px;overflow:hidden;}
 .link-cards .card-title h4 {margin:0;font-size:16px;display:flex;align-items:flex-start;}
 .link-cards .card-title h4 img {width:18px;height:18px;margin-right:5px;flex-shrink:0;}
-.link-cards .card-body p {margin:0 0 10px;font-size:14px;}
+.link-cards .card-body p {margin:0 0 10px;font-size:14px;color:#666;}
 .link-cards .card-actions {margin-top:auto;display:flex;align-items:center;gap:5px;}
 .link-cards .card-actions .move-select {padding:4px;background:#1DA1F2;color:#fff;border:none;border-radius:4px;font-family:'Rambla',sans-serif;width:fit-content;flex:0 0 auto;}
 .ad-card .ad-label{color:#6c757d;font-size:12px;text-align:left;margin-top:5px;}

--- a/load_links.php
+++ b/load_links.php
@@ -25,8 +25,8 @@ foreach($links as &$link){
     if(mb_strlen($link['titulo']) > 50){
         $link['titulo'] = mb_substr($link['titulo'], 0, 47) . '...';
     }
-    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 75){
-        $link['descripcion'] = mb_substr($link['descripcion'], 0, 72) . '...';
+    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 45){
+        $link['descripcion'] = mb_substr($link['descripcion'], 0, 42) . '...';
     }
     $domain = parse_url($link['url'], PHP_URL_HOST);
     $link['favicon'] = $domain ? getLocalFavicon($domain) : '';

--- a/panel.php
+++ b/panel.php
@@ -103,8 +103,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $link_title = mb_substr($link_title, 0, 47) . '...';
             }
             $descripcion = ensureUtf8($meta['description'] ?? '');
-            if (mb_strlen($descripcion) > 75) {
-                $descripcion = mb_substr($descripcion, 0, 72) . '...';
+            if (mb_strlen($descripcion) > 45) {
+                $descripcion = mb_substr($descripcion, 0, 42) . '...';
             }
             $imagen = $meta['image'] ?? '';
             if (empty($imagen)) {
@@ -220,8 +220,8 @@ foreach ($links as $link):
             <?php if(!empty($link['descripcion'])): ?>
                 <?php
                     $desc = $link['descripcion'];
-                    if (mb_strlen($desc) > 75) {
-                        $desc = mb_substr($desc, 0, 72) . '...';
+                    if (mb_strlen($desc) > 45) {
+                        $desc = mb_substr($desc, 0, 42) . '...';
                     }
                 ?>
                 <p><?= htmlspecialchars($desc) ?></p>

--- a/tablero_publico.php
+++ b/tablero_publico.php
@@ -56,8 +56,8 @@ include 'header.php';
             $title = mb_substr($title, 0, 47) . '...';
         }
         $desc = $link['descripcion'] ?? '';
-        if (mb_strlen($desc) > 75) {
-            $desc = mb_substr($desc, 0, 72) . '...';
+        if (mb_strlen($desc) > 45) {
+            $desc = mb_substr($desc, 0, 42) . '...';
         }
     ?>
     <div class="card">


### PR DESCRIPTION
## Summary
- Clamp card descriptions to 45 characters across panels and public boards
- Style card description text in gray for clearer distinction

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6695f6c14832c89e758674899401a