### PR TITLE
Amplía límite de descripción a 150 en desktop

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Las fichas se cargan todas inicialmente; se eliminó la carga incremental.
 
-  const MAX_DESC = 50;
+  const MAX_DESC = window.innerWidth <= 768 ? 50 : 150;
   document.querySelectorAll('.card-body p').forEach(p => {
     const text = p.textContent.trim();
     if (text.length > MAX_DESC) {

--- a/device.php
+++ b/device.php
@@ -1,0 +1,6 @@
+<?php
+function isMobile(){
+    return preg_match('/Mobile|Android|iP(hone|od|ad)|IEMobile|BlackBerry|Opera Mini/i',
+        $_SERVER['HTTP_USER_AGENT'] ?? '');
+}
+?>

--- a/load_links.php
+++ b/load_links.php
@@ -2,6 +2,7 @@
 require 'config.php';
 require 'favicon_utils.php';
 require_once 'session.php';
+require_once 'device.php';
 if(!isset($_SESSION['user_id'])){
     http_response_code(401);
     exit;
@@ -21,12 +22,13 @@ $sql .= " ORDER BY creado_en DESC LIMIT $limit OFFSET $offset";
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
 $links = $stmt->fetchAll();
+$descLimit = isMobile() ? 50 : 150;
 foreach($links as &$link){
     if(mb_strlen($link['titulo']) > 50){
         $link['titulo'] = mb_substr($link['titulo'], 0, 47) . '...';
     }
-    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > 50){
-        $link['descripcion'] = mb_substr($link['descripcion'], 0, 47) . '...';
+    if(!empty($link['descripcion']) && mb_strlen($link['descripcion']) > $descLimit){
+        $link['descripcion'] = mb_substr($link['descripcion'], 0, $descLimit - 3) . '...';
     }
     $domain = parse_url($link['url'], PHP_URL_HOST);
     $link['favicon'] = $domain ? getLocalFavicon($domain) : '';

--- a/panel.php
+++ b/panel.php
@@ -3,6 +3,7 @@ require 'config.php';
 require 'favicon_utils.php';
 require_once 'image_utils.php';
 require_once 'session.php';
+require_once 'device.php';
 if(!isset($_SESSION['user_id'])){
     header('Location: login.php');
     exit;
@@ -10,6 +11,7 @@ if(!isset($_SESSION['user_id'])){
 $user_id = $_SESSION['user_id'];
 // Categoría seleccionada (0 = todas)
 $selectedCat = isset($_GET['cat']) ? (int)$_GET['cat'] : 0;
+$descLimit = isMobile() ? 50 : 150;
 // Recuperar mensajes de error tras un posible redirect
 $error = $_SESSION['panel_error'] ?? '';
 unset($_SESSION['panel_error']);
@@ -103,8 +105,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 $link_title = mb_substr($link_title, 0, 47) . '...';
             }
             $descripcion = ensureUtf8($meta['description'] ?? '');
-            if (mb_strlen($descripcion) > 50) {
-                $descripcion = mb_substr($descripcion, 0, 47) . '...';
+            if (mb_strlen($descripcion) > $descLimit) {
+                $descripcion = mb_substr($descripcion, 0, $descLimit - 3) . '...';
             }
             $imagen = $meta['image'] ?? '';
             if (empty($imagen)) {
@@ -220,8 +222,8 @@ foreach ($links as $link):
             <?php if(!empty($link['descripcion'])): ?>
                 <?php
                     $desc = $link['descripcion'];
-                    if (mb_strlen($desc) > 50) {
-                        $desc = mb_substr($desc, 0, 47) . '...';
+                    if (mb_strlen($desc) > $descLimit) {
+                        $desc = mb_substr($desc, 0, $descLimit - 3) . '...';
                     }
                 ?>
                 <p><?= htmlspecialchars($desc) ?></p>

--- a/tablero_publico.php
+++ b/tablero_publico.php
@@ -3,6 +3,7 @@ require 'config.php';
 require 'favicon_utils.php';
 require_once 'image_utils.php';
 require_once 'session.php';
+require_once 'device.php';
 
 $token = $_GET['token'] ?? '';
 if(!$token){
@@ -21,6 +22,7 @@ if(!$board){
 $linksStmt = $pdo->prepare('SELECT url, titulo, descripcion, imagen FROM links WHERE categoria_id = ? ORDER BY id DESC');
 $linksStmt->execute([$board['id']]);
 $links = $linksStmt->fetchAll();
+$descLimit = isMobile() ? 50 : 150;
 
 $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 $shareUrl = $baseUrl . '/tablero_publico.php?token=' . $token;
@@ -56,8 +58,8 @@ include 'header.php';
             $title = mb_substr($title, 0, 47) . '...';
         }
         $desc = $link['descripcion'] ?? '';
-        if (mb_strlen($desc) > 50) {
-            $desc = mb_substr($desc, 0, 47) . '...';
+        if (mb_strlen($desc) > $descLimit) {
+            $desc = mb_substr($desc, 0, $descLimit - 3) . '...';
         }
     ?>
     <div class="card">


### PR DESCRIPTION
## Summary
- detecta dispositivos móviles con `isMobile` para ajustar límites de descripción
- extiende los textos en escritorio hasta 150 caracteres y mantiene 50 en móvil
- aplica la misma lógica en el JavaScript del cliente

## Testing
- `php -l panel.php load_links.php tablero_publico.php device.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c66d934f64832ca4c85fa33ce5579e