### PR TITLE
Show add button before mobile hamburger

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -198,12 +198,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  const openModalBtn = document.querySelector('.open-modal');
+  const openModalBtns = document.querySelectorAll('.open-modal');
   const addModal = document.querySelector('.add-modal');
-  if (openModalBtn && addModal) {
+  if (openModalBtns.length && addModal) {
     const close = () => addModal.classList.remove('show');
-    openModalBtn.addEventListener('click', () => {
-      addModal.classList.add('show');
+    openModalBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        addModal.classList.add('show');
+      });
     });
     addModal.addEventListener('click', (e) => {
       if (e.target === addModal || e.target.classList.contains('modal-close')) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -48,8 +48,10 @@ textarea {
   }
 .content {background:#fff;color:#000;padding:20px;}
 
-.open-modal{background:#1DA1F2;color:#fff;border:none;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:24px;margin-left:5px;flex-shrink:0;}
+.open-modal{background:#1DA1F2;color:#fff;border:none;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:24px;margin:0 5px;flex-shrink:0;}
 .open-modal svg{width:24px;height:24px;}
+.add-mobile{display:none;}
+@media (max-width:600px){.add-mobile{display:flex;}.top-menu .menu .add-menu{display:none;}}
 .search-toggle{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;margin-left:5px;flex-shrink:0;}
 .search-toggle svg{width:20px;height:20px;}
 .board-scroll{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;flex-shrink:0;}

--- a/header.php
+++ b/header.php
@@ -25,6 +25,9 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
 <header class="top-menu">
     <div class="logo"><a href="/panel.php"><img src="/img/linkaloo_white.png" alt="linkaloo"><!-- Logo file already on server --></a></div>
     <nav>
+        <?php if(isset($_SESSION['user_id']) && isset($categorias)): ?>
+            <button type="button" class="open-modal add-mobile" aria-label="Añadir"><i data-feather="plus"></i></button>
+        <?php endif; ?>
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">
             <?php if(isset($_SESSION['user_id'])): ?>


### PR DESCRIPTION
## Summary
- Display the add-link/board button to the left of the hamburger menu on mobile
- Hide duplicate add button in collapsed menu on small screens and adjust open-modal spacing
- Support multiple add buttons in JavaScript modal logic

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c66f7bddf4832ca4d896b6d5ffbf22