### PR TITLE
Permitir crear tablero al guardar favolink

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -70,15 +70,15 @@ textarea {
 .control-forms .form-section h3{text-align:center;margin:0;color:#6c757d;}
 .control-forms .form-section form{width:100%;}
 .control-forms form{display:flex;gap:5px;flex-wrap:wrap;}
-.control-forms .form-categoria{flex-wrap:nowrap;}
-.control-forms .form-categoria input{flex:1;}
 .control-forms input,
 .control-forms select{padding:10px;padding-left:20px;border:1px solid #ccc;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;}
 .control-forms button{padding:10px 20px;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;background:#1DA1F2;color:#fff;border:none;text-align:center;}
 .control-forms select{background:#f0e8e8;color:#000;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
 .control-forms select option[value=""]{color:#6c757d;}
 
-.form-separator{border:0;border-top:1px solid #ccc;margin:10px 0;}
+.form-link .select-create{display:flex;gap:5px;}
+.form-link .select-create select,
+.form-link .select-create input{flex:1;}
 @media(min-width:601px){
   .form-link{flex-direction:column;align-items:stretch;}
   .form-link input,

--- a/header.php
+++ b/header.php
@@ -60,26 +60,21 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
     <div class="add-modal-content" style="padding: 30px;">
         <button type="button" class="modal-close" aria-label="Cerrar">&times;</button>
         <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-        <h2 class="modal-title">Guarda, organiza, comparte</h2>
+        <h2 class="modal-title">Añadir tu favolink</h2>
         <div class="control-forms">
             <div class="form-section">
-                <form method="post" class="form-categoria">
-                    <input type="text" name="categoria_nombre" placeholder="Nombre del tablero nuevo">
-                    <button type="submit">Crear</button>
-                </form>
-            </div>
-            <hr class="form-separator">
-            <div class="form-section">
-                <h3>Añadir tu favolink</h3>
                 <form method="post" class="form-link">
-                    <input type="url" name="link_url" placeholder="pega aquí el link" required>
-                    <input type="text" name="link_title" placeholder="Titulo (opcional)" maxlength="50">
-                    <select name="categoria_id" required>
-                        <option value="">Elige el tablero</option>
-                        <?php foreach($categorias as $categoria): ?>
-                            <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-                        <?php endforeach; ?>
-                    </select>
+                    <input type="url" name="link_url" placeholder="Pega aquí el link" required>
+                    <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
+                    <div class="select-create">
+                        <select name="categoria_id">
+                            <option value="">Elige el tablero</option>
+                            <?php foreach($categorias as $categoria): ?>
+                                <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <input type="text" name="categoria_nombre" placeholder="o crear uno nuevo">
+                    </div>
                     <button type="submit">Guardar favolink</button>
                 </form>
             </div>

--- a/panel.php
+++ b/panel.php
@@ -85,16 +85,16 @@ function scrapeMetadata($url){
 }
 
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
-    if(isset($_POST['categoria_nombre'])){
-        $categoria_nombre = trim($_POST['categoria_nombre']);
+    if(isset($_POST['link_url'])){
+        $link_url = trim($_POST['link_url']);
+        $link_title = trim($_POST['link_title']);
+        $categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 0;
+        $categoria_nombre = trim($_POST['categoria_nombre'] ?? '');
         if($categoria_nombre){
             $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
             $stmt->execute([$user_id, $categoria_nombre]);
+            $categoria_id = (int)$pdo->lastInsertId();
         }
-    } elseif(isset($_POST['link_url'])){
-        $link_url = trim($_POST['link_url']);
-        $link_title = trim($_POST['link_title']);
-        $categoria_id = (int)$_POST['categoria_id'];
         if($link_url && $categoria_id){
             $meta = scrapeMetadata($link_url);
             if(!$link_title && !empty($meta['title'])){


### PR DESCRIPTION
## Summary
- Reorganiza el modal de guardado de enlaces para incluir el selector de tablero junto a la creación de uno nuevo.
- Al guardar, si se indica un nombre de tablero, se crea y se asigna al enlace automáticamente.
- Ajustes de estilo para alinear selector e input en una sola fila.

## Testing
- `php -l config.php panel.php move_link.php load_links.php header.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c67763c3f8832c88eadaf5c2671b14