### PR TITLE
Move new board input below board selector

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -76,7 +76,7 @@ textarea {
 .control-forms select{background:#f0e8e8;color:#000;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
 .control-forms select option[value=""]{color:#6c757d;}
 
-.form-link .select-create{display:flex;gap:5px;}
+.form-link .select-create{display:flex;flex-direction:column;gap:5px;}
 .form-link .select-create select,
 .form-link .select-create input{flex:1;}
 @media(min-width:601px){

--- a/header.php
+++ b/header.php
@@ -73,7 +73,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                                 <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <input type="text" name="categoria_nombre" placeholder="o crear uno nuevo">
+                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)">
                     </div>
                     <button type="submit">Guardar favolink</button>
                 </form>


### PR DESCRIPTION
## Summary
- Allow adding a new board by placing its text input below the "Elige el tablero" selector and clarify it as optional

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c679ecc7fc832c8f6ee5d1cf07db86