### PR TITLE
Ensure modal inputs span full width on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -86,9 +86,10 @@ textarea {
   .form-link button{flex:1 1 100%;font-size:18px;}
 }
 @media(max-width:600px){
+  .form-link{flex-direction:column;align-items:stretch;}
   .form-link input,
   .form-link select,
-  .form-link button{flex:1 1 100%;}
+  .form-link button{flex:1 1 100%;width:100%;}
 }
 
 @media (min-width:601px){


### PR DESCRIPTION
## Summary
- Make modal form elements full width on mobile

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c67c3611c4832c90be1f414a82b0a3