### PR TITLE
feat: allow selecting boards after signup

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -228,6 +228,19 @@ textarea {
 .board-detail-form button{padding:10px 20px;border-radius:20px;font-family:'Rambla',sans-serif;font-size:16px;background:#1DA1F2;color:#fff;border:none;text-align:center;cursor:pointer;}
 .links-link{background:#1DA1F2;color:#fff;border:none;padding:8px 16px;border-radius:4px;cursor:pointer;text-decoration:none;display:inline-block;text-align:center;}
 @media (max-width:600px){
-  .board-detail{flex-direction:column;}
+.board-detail{flex-direction:column;}
 }
 
+/* Board selection */
+.board-select{max-width:600px;margin:0 auto;text-align:center;}
+.board-select h2{margin-bottom:5px;}
+.board-select p{color:#6c757d;margin:0 0 20px;}
+.board-options{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-bottom:20px;}
+.board-option{position:relative;}
+.board-option input{display:none;}
+.board-option span{display:inline-block;padding:8px 15px;border:1px solid #ccc;border-radius:20px;cursor:pointer;color:#000;background:#f5f8fa;}
+.board-option input:checked + span{background:#1DA1F2;color:#fff;border-color:#1DA1F2;}
+.board-select-buttons{display:flex;justify-content:space-between;max-width:300px;margin:0 auto;}
+.board-select-buttons a,.board-select-buttons button{flex:1;padding:10px;border-radius:20px;text-align:center;text-decoration:none;}
+.board-select-buttons a{margin-right:10px;background:#f5f8fa;color:#000;}
+.board-select-buttons button{background:#1DA1F2;color:#fff;border:none;cursor:pointer;}

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -65,20 +65,20 @@ $user = $stmt->fetch();
 if ($user) {
     $userId   = $user['id'];
     $userName = $user['nombre'];
+    $_SESSION['user_id']   = $userId;
+    $_SESSION['user_name'] = $userName;
+    header('Location: panel.php');
+    exit;
 } else {
     $passHash = password_hash(bin2hex(random_bytes(16)), PASSWORD_DEFAULT);
     $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
     $stmt->execute([$name ?: $email, $email, $passHash]);
     $userId   = $pdo->lastInsertId();
-    $catStmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
-    $catStmt->execute([$userId, 'Sin Categoria']);
     $userName = $name ?: $email;
+    $_SESSION['user_id']   = $userId;
+    $_SESSION['user_name'] = $userName;
+    header('Location: seleccion_tableros.php');
+    exit;
 }
-
-$_SESSION['user_id']   = $userId;
-$_SESSION['user_name'] = $userName;
-
-header('Location: panel.php');
-exit;
 ?>
 

--- a/register.php
+++ b/register.php
@@ -17,11 +17,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
             $stmt->execute([$nombre, $email, $hash]);
             $userId = $pdo->lastInsertId();
-            $catStmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
-            $catStmt->execute([$userId, 'Sin Categoria']);
             $_SESSION['user_id'] = $userId;
             $_SESSION['user_name'] = $nombre;
-            header('Location: panel.php');
+            header('Location: seleccion_tableros.php');
             exit;
         }
     } else {

--- a/seleccion_tableros.php
+++ b/seleccion_tableros.php
@@ -1,0 +1,67 @@
+<?php
+require 'config.php';
+require_once 'session.php';
+if(!isset($_SESSION['user_id'])){
+    header('Location: login.php');
+    exit;
+}
+$user_id = $_SESSION['user_id'];
+
+$predefinedBoards = [
+    'Ciencias y educación',
+    'Deportes',
+    'Fitness y salud',
+    'Música',
+    'Comedia',
+    'Comida y bebida',
+    'Automoción y vehículos',
+    'DIY',
+    'Animales',
+    'Belleza y estilo',
+    'Viajes',
+    'Motivación y consejos',
+    'Gaming',
+    'Entretenimiento',
+    'Arte',
+    'Trucos para la vida cotidiana',
+    'Actividades al aire libre',
+];
+
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    $selected = $_POST['boards'] ?? [];
+    if(is_array($selected)){
+        $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+        foreach($selected as $board){
+            $board = trim($board);
+            if($board){
+                $stmt->execute([$user_id, $board]);
+            }
+        }
+    }
+    header('Location: panel.php');
+    exit;
+}
+
+include 'header.php';
+?>
+<div class="board-select">
+    <h2>Elige tus intereses</h2>
+    <p>Recibe mejores sugerencias de vídeos</p>
+    <form method="post">
+        <div class="board-options">
+            <?php foreach($predefinedBoards as $board): ?>
+            <label class="board-option">
+                <input type="checkbox" name="boards[]" value="<?= htmlspecialchars($board) ?>">
+                <span><?= htmlspecialchars($board) ?></span>
+            </label>
+            <?php endforeach; ?>
+        </div>
+        <div class="board-select-buttons">
+            <a href="panel.php" class="skip-btn">Omitir</a>
+            <button type="submit" class="next-btn">Siguiente</button>
+        </div>
+    </form>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect new users to an interest board selection instead of creating a default board
- add selection page with preset board options and styling
- update OAuth signup flow to use new selection page

## Testing
- `npm run lint:css`
- `php -l register.php oauth2callback.php seleccion_tableros.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6a9f05c18832c99705798a5298ff9