### PR TITLE
Improve login block responsiveness

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -165,13 +165,20 @@ textarea {
 .social-btn.instagram {background:#E1306C;}
 .social-btn.google {background:#DB4437;}
 .social-btn.facebook {background:#4267B2;}
+@media (min-width:601px){
+  .login-block,
+  .social-block{
+    max-width:450px;
+  }
+}
 @media (max-width:600px){
-  .login-wrapper{flex-direction:column;min-height:auto;max-height:600px;}
+  .login-wrapper{flex-direction:column;min-height:auto;max-height:none;}
   .login-block,
   .social-block{
     width:100%;
     height:auto;
-    max-height:290px;
+    max-height:none;
+    overflow:visible;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow login blocks to expand on mobile so content fits without inner scrolling
- cap login block width to 450px on larger screens for better layout

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c72c967b00832c8b5fb7bebec60798