### PR TITLE
Show blue logo on registration page

### DIFF
--- a/register.php
+++ b/register.php
@@ -28,6 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 include 'header.php';
 ?>
+<div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
 <div class="login-wrapper">
     <div class="login-block">
         <h2>Registro</h2>


### PR DESCRIPTION
## Summary
- Add blue Linkaloo logo above registration form for consistent branding.

## Testing
- `php -l config.php panel.php move_link.php load_links.php register.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c72fd6b3e8832ca2153974b582b155