### PR TITLE
Add password reset flow

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -39,3 +39,11 @@ CREATE TABLE links (
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE password_resets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    token VARCHAR(255) NOT NULL,
+    expiracion DATETIME NOT NULL,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/login.php
+++ b/login.php
@@ -36,7 +36,7 @@ include 'header.php';
         </form>
         <div class="login-links">
             <a href="register.php">Registrarse</a>
-            <a href="#">¿Olvidaste tu contraseña?</a>
+            <a href="recuperar_password.php">¿Olvidaste tu contraseña?</a>
         </div>
         <h3>O ingresa con</h3>
         <a class="social-btn google" href="oauth.php?provider=google">Google</a>

--- a/recuperar_password.php
+++ b/recuperar_password.php
@@ -1,0 +1,41 @@
+<?php
+require 'config.php';
+require_once 'session.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    if ($email) {
+        $stmt = $pdo->prepare('SELECT id FROM usuarios WHERE email = ?');
+        $stmt->execute([$email]);
+        $user = $stmt->fetch();
+        if ($user) {
+            $token = bin2hex(random_bytes(16));
+            $stmt = $pdo->prepare('INSERT INTO password_resets (usuario_id, token, expiracion) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 HOUR))');
+            $stmt->execute([$user['id'], $token]);
+            $resetLink = "https://linkaloo.com/restablecer_password.php?token=$token";
+            @mail($email, 'Recuperar contraseña', "Haz clic en el siguiente enlace para restablecer tu contraseña: $resetLink");
+        }
+        $message = 'Si el correo existe, hemos enviado instrucciones a tu email.';
+    } else {
+        $message = 'Introduce un correo válido';
+    }
+}
+include 'header.php';
+?>
+<div class="login-wrapper">
+    <div class="login-block">
+        <h2>Recuperar contraseña</h2>
+        <?php if($message): ?><p class="notice"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+        <form method="post" class="login-form">
+            <input type="email" name="email" placeholder="Email">
+            <button type="submit">Enviar enlace</button>
+        </form>
+        <div class="login-links">
+            <a href="login.php">Volver al login</a>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -41,7 +41,7 @@ include 'header.php';
         </form>
         <div class="login-links">
             <a href="login.php">Iniciar sesión</a>
-            <a href="#">¿Olvidaste tu contraseña?</a>
+            <a href="recuperar_password.php">¿Olvidaste tu contraseña?</a>
         </div>
     </div>
     <!--

--- a/restablecer_password.php
+++ b/restablecer_password.php
@@ -1,0 +1,56 @@
+<?php
+require 'config.php';
+require_once 'session.php';
+
+$token = $_GET['token'] ?? '';
+$message = '';
+$showForm = false;
+
+if ($token) {
+    $stmt = $pdo->prepare('SELECT usuario_id FROM password_resets WHERE token = ? AND expiracion > NOW()');
+    $stmt->execute([$token]);
+    $row = $stmt->fetch();
+    if ($row) {
+        $showForm = true;
+        $userId = $row['usuario_id'];
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $password = $_POST['password'] ?? '';
+            if ($password) {
+                $hash = password_hash($password, PASSWORD_BCRYPT);
+                $stmt = $pdo->prepare('UPDATE usuarios SET pass_hash = ? WHERE id = ?');
+                $stmt->execute([$hash, $userId]);
+                $stmt = $pdo->prepare('DELETE FROM password_resets WHERE token = ?');
+                $stmt->execute([$token]);
+                $message = 'Contraseña actualizada. Ahora puedes iniciar sesión.';
+                $showForm = false;
+            } else {
+                $message = 'Introduce una nueva contraseña';
+            }
+        }
+    } else {
+        $message = 'Enlace de recuperación inválido o expirado.';
+    }
+} else {
+    $message = 'Token no válido.';
+}
+
+include 'header.php';
+?>
+<div class="login-wrapper">
+    <div class="login-block">
+        <h2>Restablecer contraseña</h2>
+        <?php if($message): ?><p class="notice"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+        <?php if($showForm): ?>
+        <form method="post" class="login-form">
+            <input type="password" name="password" placeholder="Nueva contraseña">
+            <button type="submit">Guardar contraseña</button>
+        </form>
+        <?php endif; ?>
+        <div class="login-links">
+            <a href="login.php">Iniciar sesión</a>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `recuperar_password.php` for requesting password reset links
- Add `restablecer_password.php` to update password using reset tokens
- Link recovery page from login and registration forms and add `password_resets` table to schema

## Testing
- `php -l recuperar_password.php`
- `php -l restablecer_password.php`
- `php -l login.php`
- `php -l register.php`
- `npm test` *(fails: no test specified)*
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68c7309c9bc4832c91a4e006003472dd