### PR TITLE
Add reCAPTCHA human verification to user auth

### DIFF
--- a/config.php
+++ b/config.php
@@ -25,4 +25,8 @@ try {
 $googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-8ise1fcsud3mv3552bt7hrck3o7o6n31.apps.googleusercontent.com';
 $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
 $googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback.php';
+
+// reCAPTCHA configuration (set your keys in environment variables)
+$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY') ?: '';
+$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY') ?: '';
 ?>


### PR DESCRIPTION
## Summary
- add reCAPTCHA configuration via environment variables
- require CAPTCHA validation on registration and login forms
- render reCAPTCHA widgets on auth pages

## Testing
- `php -l register.php`
- `php -l login.php`
- `php -l config.php`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c734e629fc832ca779de195c59b930