### PR TITLE
docs: add API endpoint reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Este directorio reúne los documentos principales del proyecto:
 - `estructura.md`: visión general de la arquitectura y de la base de datos.
 - `instalacion.md`: guía para preparar un entorno local de desarrollo.
 - `uso.md`: instrucciones paso a paso para utilizar la aplicación.
+- `endpoints.md`: referencia de los scripts PHP que actúan como API.
 
 ## Comprobaciones rápidas
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,35 @@
+# Endpoints de la API
+
+Este documento describe los scripts PHP que actúan como puntos de entrada para las operaciones asíncronas del cliente.
+Todos requieren que el usuario tenga una sesión activa; de lo contrario devuelven un código 401 o `success: false`.
+
+## `load_links.php`
+
+Obtiene un lote de enlaces del usuario.
+
+- **Método:** `GET`
+- **Parámetros:**
+  - `offset` (entero, opcional): número de enlaces ya cargados. Por defecto `0`.
+  - `cat` (entero o `"all"`, opcional): identificador del tablero. Si se omite o vale `all`, devuelve enlaces de todos los tableros.
+- **Respuesta:** matriz JSON con objetos que incluyen `id`, `categoria_id`, `url`, `titulo`, `descripcion`, `imagen` y `favicon`.
+
+## `move_link.php`
+
+Mueve un enlace a otro tablero.
+
+- **Método:** `POST`
+- **Parámetros:**
+  - `id` (entero, obligatorio): identificador del enlace.
+  - `categoria_id` (entero, obligatorio): identificador del tablero destino.
+- **Respuesta:** objeto JSON `{ "success": true }` si la operación se realiza correctamente, en caso contrario `{ "success": false }`.
+
+## `delete_link.php`
+
+Elimina un enlace existente.
+
+- **Método:** `POST`
+- **Parámetros:**
+  - `id` (entero, obligatorio): identificador del enlace a borrar.
+- **Respuesta:** objeto JSON con `success: true` si se borra el enlace; en caso contrario `success: false`.
+
+Estos endpoints actualizan la marca de modificación del tablero afectado para mantener la información sincronizada.


### PR DESCRIPTION
## Summary
- document AJAX endpoints used by the web app
- reference the new endpoint documentation in the docs index

## Testing
- `php -l config.php panel.php move_link.php load_links.php`
- `node --check assets/main.js`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c73862e6ec832cab353fd6c2424819