### PR TITLE
Fix reCAPTCHA key retrieval in config

### DIFF
--- a/config.php
+++ b/config.php
@@ -27,6 +27,8 @@ $googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: 'GOCSPX-zi0kL3Imqj67mcH8
 $googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback.php';
 
 // reCAPTCHA configuration (set your keys in environment variables)
-$recaptchaSiteKey   = getenv('6Lf8pckrAAAAAE5BqEQKcugNtA_34k6-ErygC4vB') ?: '';
-$recaptchaSecretKey = getenv('6Lf8pckrAAAAAGdoqnT9mw0PwMzBB9VIuKuxsN-_') ?: '';
+// Use environment variables `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` or
+// fall back to hard-coded keys if provided.
+$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY') ?: '6Lf8pckrAAAAAE5BqEQKcugNtA_34k6-ErygC4vB';
+$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY') ?: '6Lf8pckrAAAAAGdoqnT9mw0PwMzBB9VIuKuxsN-_';
 ?>


### PR DESCRIPTION
## Summary
- Read reCAPTCHA keys from `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` environment variables
- Provide optional hard-coded fallback keys

## Testing
- `php -l config.php`
- `npm test` (fails: Error: no test specified)
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68c73aa7e2cc832cbaa4c65a55fbe74d