### PR TITLE
Add persistent login with long-lived remember me tokens

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -47,3 +47,15 @@ CREATE TABLE password_resets (
     expiracion DATETIME NOT NULL,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE usuario_tokens (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    selector CHAR(32) NOT NULL UNIQUE,
+    token_hash CHAR(64) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    creado_en DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    INDEX idx_usuario_tokens_usuario (usuario_id),
+    INDEX idx_usuario_tokens_expires (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/login.php
+++ b/login.php
@@ -21,8 +21,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->execute([$email]);
             $user = $stmt->fetch();
             if ($user && password_verify($password, $user['pass_hash'])) {
-                $_SESSION['user_id'] = $user['id'];
+                session_regenerate_id(true);
+                $_SESSION['user_id'] = (int) $user['id'];
                 $_SESSION['user_name'] = $user['nombre'];
+                linkalooIssueRememberMeToken($pdo, (int) $user['id']);
                 header('Location: panel.php');
                 exit;
             } else {

--- a/logout.php
+++ b/logout.php
@@ -1,6 +1,17 @@
 <?php
+require 'config.php';
 require_once 'session.php';
+
+linkalooClearRememberMeToken($pdo);
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+} else {
+    setcookie(session_name(), '', time() - 42000, '/');
+}
+
 session_destroy();
-setcookie(session_name(), '', time() - 3600, '/');
 header('Location: login.php');
 exit;

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -63,20 +63,24 @@ $stmt->execute([$email]);
 $user = $stmt->fetch();
 
 if ($user) {
-    $userId   = $user['id'];
+    $userId   = (int) $user['id'];
     $userName = $user['nombre'];
+    session_regenerate_id(true);
     $_SESSION['user_id']   = $userId;
     $_SESSION['user_name'] = $userName;
+    linkalooIssueRememberMeToken($pdo, $userId);
     header('Location: panel.php');
     exit;
 } else {
     $passHash = password_hash(bin2hex(random_bytes(16)), PASSWORD_DEFAULT);
     $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
     $stmt->execute([$name ?: $email, $email, $passHash]);
-    $userId   = $pdo->lastInsertId();
+    $userId   = (int) $pdo->lastInsertId();
     $userName = $name ?: $email;
+    session_regenerate_id(true);
     $_SESSION['user_id']   = $userId;
     $_SESSION['user_name'] = $userName;
+    linkalooIssueRememberMeToken($pdo, $userId);
     header('Location: seleccion_tableros.php');
     exit;
 }

--- a/register.php
+++ b/register.php
@@ -26,9 +26,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $hash = password_hash($password, PASSWORD_BCRYPT);
                 $stmt = $pdo->prepare('INSERT INTO usuarios (nombre, email, pass_hash) VALUES (?, ?, ?)');
                 $stmt->execute([$nombre, $email, $hash]);
-                $userId = $pdo->lastInsertId();
+                $userId = (int) $pdo->lastInsertId();
+                session_regenerate_id(true);
                 $_SESSION['user_id'] = $userId;
                 $_SESSION['user_name'] = $nombre;
+                linkalooIssueRememberMeToken($pdo, $userId);
                 header('Location: seleccion_tableros.php');
                 exit;
             }

--- a/session.php
+++ b/session.php
@@ -1,15 +1,170 @@
 <?php
-$lifetime = 365 * 24 * 60 * 60; // 365 días
-ini_set('session.gc_maxlifetime', $lifetime);
+if (!defined('LINKALOO_SESSION_LIFETIME')) {
+    define('LINKALOO_SESSION_LIFETIME', 365 * 24 * 60 * 60); // 365 días
+}
+
+if (!defined('LINKALOO_REMEMBER_COOKIE_NAME')) {
+    define('LINKALOO_REMEMBER_COOKIE_NAME', 'linkaloo_remember');
+}
+
+ini_set('session.gc_maxlifetime', LINKALOO_SESSION_LIFETIME);
+ini_set('session.cookie_lifetime', LINKALOO_SESSION_LIFETIME);
+
 session_set_cookie_params([
-    'lifetime' => $lifetime,
-    'path' => '/',
-    'domain' => '',
-    'secure' => !empty($_SERVER['HTTPS']),
+    'lifetime' => LINKALOO_SESSION_LIFETIME,
+    'path'     => '/',
+    'domain'   => '',
+    'secure'   => !empty($_SERVER['HTTPS']),
     'httponly' => true,
-    'samesite' => 'Lax'
+    'samesite' => 'Lax',
 ]);
+
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
+}
+
+if (!function_exists('linkalooRememberCookieOptions')) {
+    function linkalooRememberCookieOptions(int $expires): array
+    {
+        return [
+            'expires'  => $expires,
+            'path'     => '/',
+            'domain'   => '',
+            'secure'   => !empty($_SERVER['HTTPS']),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ];
+    }
+}
+
+if (!function_exists('linkalooIssueRememberMeToken')) {
+    function linkalooIssueRememberMeToken(PDO $pdo, int $userId): void
+    {
+        try {
+            $pdo->prepare('DELETE FROM usuario_tokens WHERE usuario_id = ?')->execute([$userId]);
+
+            $selector  = bin2hex(random_bytes(16));
+            $validator = bin2hex(random_bytes(32));
+            $tokenHash = hash('sha256', $validator);
+            $expiresAt = date('Y-m-d H:i:s', time() + LINKALOO_SESSION_LIFETIME);
+
+            $stmt = $pdo->prepare('INSERT INTO usuario_tokens (usuario_id, selector, token_hash, expires_at) VALUES (?, ?, ?, ?)');
+            $stmt->execute([$userId, $selector, $tokenHash, $expiresAt]);
+        } catch (Throwable $exception) {
+            error_log('Error issuing remember-me token: ' . $exception->getMessage());
+            return;
+        }
+
+        $cookieValue = $selector . ':' . $validator;
+        setcookie(LINKALOO_REMEMBER_COOKIE_NAME, $cookieValue, linkalooRememberCookieOptions(time() + LINKALOO_SESSION_LIFETIME));
+        $_COOKIE[LINKALOO_REMEMBER_COOKIE_NAME] = $cookieValue;
+    }
+}
+
+if (!function_exists('linkalooDeleteRememberToken')) {
+    function linkalooDeleteRememberToken(PDO $pdo, string $selector): void
+    {
+        if ($selector === '') {
+            return;
+        }
+
+        try {
+            $stmt = $pdo->prepare('DELETE FROM usuario_tokens WHERE selector = ?');
+            $stmt->execute([$selector]);
+        } catch (Throwable $exception) {
+            error_log('Error deleting remember-me token: ' . $exception->getMessage());
+        }
+    }
+}
+
+if (!function_exists('linkalooClearRememberMeToken')) {
+    function linkalooClearRememberMeToken(PDO $pdo): void
+    {
+        $cookieValue = $_COOKIE[LINKALOO_REMEMBER_COOKIE_NAME] ?? null;
+        if ($cookieValue && strpos($cookieValue, ':') !== false) {
+            [$selector] = explode(':', $cookieValue, 2);
+            linkalooDeleteRememberToken($pdo, $selector);
+        }
+
+        setcookie(LINKALOO_REMEMBER_COOKIE_NAME, '', linkalooRememberCookieOptions(time() - 3600));
+        unset($_COOKIE[LINKALOO_REMEMBER_COOKIE_NAME]);
+    }
+}
+
+if (!function_exists('linkalooAttemptAutoLogin')) {
+    function linkalooAttemptAutoLogin(PDO $pdo): void
+    {
+        $cookieValue = $_COOKIE[LINKALOO_REMEMBER_COOKIE_NAME] ?? null;
+        if (!$cookieValue || strpos($cookieValue, ':') === false) {
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        [$selector, $validator] = explode(':', $cookieValue, 2);
+        if ($selector === '' || $validator === '') {
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        try {
+            $stmt = $pdo->prepare('SELECT usuario_id, token_hash, expires_at FROM usuario_tokens WHERE selector = ? LIMIT 1');
+            $stmt->execute([$selector]);
+            $tokenRow = $stmt->fetch();
+        } catch (Throwable $exception) {
+            error_log('Error retrieving remember-me token: ' . $exception->getMessage());
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        if (!$tokenRow) {
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        if (strtotime($tokenRow['expires_at']) < time()) {
+            linkalooDeleteRememberToken($pdo, $selector);
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        $expectedHash  = $tokenRow['token_hash'];
+        $validatorHash = hash('sha256', $validator);
+        if (!hash_equals($expectedHash, $validatorHash)) {
+            linkalooDeleteRememberToken($pdo, $selector);
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        try {
+            $userStmt = $pdo->prepare('SELECT id, nombre FROM usuarios WHERE id = ? LIMIT 1');
+            $userStmt->execute([(int) $tokenRow['usuario_id']]);
+            $user = $userStmt->fetch();
+        } catch (Throwable $exception) {
+            error_log('Error retrieving user for remember-me login: ' . $exception->getMessage());
+            linkalooDeleteRememberToken($pdo, $selector);
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        if (!$user) {
+            linkalooDeleteRememberToken($pdo, $selector);
+            linkalooClearRememberMeToken($pdo);
+            return;
+        }
+
+        session_regenerate_id(true);
+        $_SESSION['user_id']   = (int) $user['id'];
+        $_SESSION['user_name'] = $user['nombre'];
+
+        linkalooIssueRememberMeToken($pdo, (int) $user['id']);
+    }
+}
+
+if (empty($_SESSION['user_id']) && !empty($_COOKIE[LINKALOO_REMEMBER_COOKIE_NAME])) {
+    if (!isset($pdo) || !($pdo instanceof PDO)) {
+        require_once __DIR__ . '/config.php';
+    }
+
+    linkalooAttemptAutoLogin($pdo);
 }
 ?>


### PR DESCRIPTION
## Summary
- add remember-me token handling in the session bootstrap to keep users signed in for up to 365 days and automatically recreate sessions when the cookie is present
- regenerate the PHP session ID and issue persistent login tokens after classic, registration, and Google OAuth logins, and revoke the token on logout
- document the new `usuario_tokens` table used to store long-lived session tokens

## Testing
- php -l session.php
- php -l login.php
- php -l register.php
- php -l oauth2callback.php
- php -l logout.php

------
https://chatgpt.com/codex/tasks/task_e_68c963d90adc832cb9ecdd9f50cd2763