### PR TITLE
Handle Android shared links by propagating to panel

### DIFF
--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.util.Patterns
 import androidx.appcompat.app.AppCompatActivity
 
 class ShareReceiverActivity : AppCompatActivity() {
@@ -34,10 +35,23 @@ class ShareReceiverActivity : AppCompatActivity() {
     }
 
     private fun handleLink(link: String) {
-        Log.d("ShareReceiver", "Received link: $link")
-        // Abre Linkaloo con el enlace compartido como parámetro
-        val encoded = Uri.encode(link)
-        val uri = Uri.parse("https://linkaloo.com/?shared=" + encoded)
-        startActivity(Intent(Intent.ACTION_VIEW, uri))
+        val matcher = Patterns.WEB_URL.matcher(link)
+        if (!matcher.find()) {
+            Log.w("ShareReceiver", "No valid URL found in shared content")
+            return
+        }
+
+        var sharedUrl = link.substring(matcher.start(), matcher.end()).trim()
+        if (!sharedUrl.startsWith("http://", ignoreCase = true) &&
+            !sharedUrl.startsWith("https://", ignoreCase = true)
+        ) {
+            sharedUrl = "https://$sharedUrl"
+        }
+
+        Log.d("ShareReceiver", "Forwarding shared link: $sharedUrl")
+        val targetUri = Uri.parse("https://linkaloo.com/panel.php").buildUpon()
+            .appendQueryParameter("shared", sharedUrl)
+            .build()
+        startActivity(Intent(Intent.ACTION_VIEW, targetUri))
     }
 }

--- a/assets/main.js
+++ b/assets/main.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (window.feather) {
     feather.replace();
   }
+  const params = new URLSearchParams(window.location.search);
   const toggle = document.querySelector('.menu-toggle');
   const menu = document.querySelector('.top-menu ul');
   if (toggle && menu) {
@@ -50,29 +51,28 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-    if (buttons.length) {
-      const params = new URLSearchParams(window.location.search);
-      const initial = params.get('cat');
-      let activeBtn = buttons[0];
-      if (initial) {
-        const found = Array.from(buttons).find(b => b.dataset.cat === initial);
-        if (found) activeBtn = found;
-      }
-      currentCat = activeBtn.dataset.cat;
-      filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-      activeBtn.classList.add('active');
-      buttons.forEach(btn => {
-        btn.addEventListener('click', () => {
-          if (boardSlider) {
-            sessionStorage.setItem('boardScroll', boardSlider.scrollLeft);
-          }
-          buttons.forEach(b => b.classList.remove('active'));
-          btn.classList.add('active');
-          currentCat = btn.dataset.cat;
-          filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
-        });
-      });
+  if (buttons.length) {
+    const initial = params.get('cat');
+    let activeBtn = buttons[0];
+    if (initial) {
+      const found = Array.from(buttons).find(b => b.dataset.cat === initial);
+      if (found) activeBtn = found;
     }
+    currentCat = activeBtn.dataset.cat;
+    filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
+    activeBtn.classList.add('active');
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (boardSlider) {
+          sessionStorage.setItem('boardScroll', boardSlider.scrollLeft);
+        }
+        buttons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        currentCat = btn.dataset.cat;
+        filter(currentCat, searchInput ? searchInput.value.toLowerCase() : '');
+      });
+    });
+  }
 
 
   document.querySelectorAll('.share-board').forEach(btn => {
@@ -200,6 +200,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const openModalBtns = document.querySelectorAll('.open-modal');
   const addModal = document.querySelector('.add-modal');
+  const linkInput = addModal ? addModal.querySelector('.form-link [name="link_url"]') : null;
   if (openModalBtns.length && addModal) {
     const close = () => addModal.classList.remove('show');
     openModalBtns.forEach(btn => {
@@ -212,6 +213,30 @@ document.addEventListener('DOMContentLoaded', () => {
         close();
       }
     });
+  }
+
+  const sharedParam = params.get('shared');
+  if (sharedParam && addModal && linkInput) {
+    const candidate = sharedParam.trim();
+    let validUrl = '';
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        validUrl = parsed.toString();
+      }
+    } catch (_) {}
+
+    if (validUrl) {
+      linkInput.value = validUrl;
+      addModal.classList.add('show');
+      try { linkInput.focus(); } catch (_) {}
+      params.delete('shared');
+      if (typeof history.replaceState === 'function') {
+        const newQuery = params.toString();
+        const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash}`;
+        history.replaceState(null, '', newUrl);
+      }
+    }
   }
 
   document.addEventListener('click', (e) => {

--- a/index.php
+++ b/index.php
@@ -1,8 +1,10 @@
 <?php
 require_once 'session.php';
+$query = $_SERVER['QUERY_STRING'] ?? '';
+$suffix = $query ? '?' . $query : '';
 if(isset($_SESSION['user_id'])){
-    header('Location: panel.php');
+    header('Location: panel.php' . $suffix);
 } else {
-    header('Location: login.php');
+    header('Location: login.php' . $suffix);
 }
 exit;

--- a/login.php
+++ b/login.php
@@ -2,6 +2,16 @@
 require 'config.php';
 require_once 'session.php';
 
+$sharedParam = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $sharedParam = trim($_POST['shared'] ?? '');
+} elseif (isset($_GET['shared'])) {
+    $sharedParam = trim($_GET['shared']);
+}
+if ($sharedParam !== '' && !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
+    $sharedParam = '';
+}
+
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = $_POST['email'] ?? '';
@@ -25,7 +35,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_SESSION['user_id'] = (int) $user['id'];
                 $_SESSION['user_name'] = $user['nombre'];
                 linkalooIssueRememberMeToken($pdo, (int) $user['id']);
-                header('Location: panel.php');
+                $redirect = 'panel.php';
+                if ($sharedParam !== '') {
+                    $redirect .= '?shared=' . rawurlencode($sharedParam);
+                }
+                header('Location: ' . $redirect);
                 exit;
             } else {
                 $error = 'Usuario o contraseña incorrectos';
@@ -47,6 +61,7 @@ include 'header.php';
         <form method="post" class="login-form" id="login-form">
             <input type="email" name="email" placeholder="Email">
             <input type="password" name="password" placeholder="Contraseña">
+            <input type="hidden" name="shared" value="<?= htmlspecialchars($sharedParam, ENT_QUOTES, 'UTF-8') ?>">
             <?php if(!empty($recaptchaSiteKey)): ?>
             <input type="hidden" name="g-recaptcha-response" id="g-recaptcha-response">
             <?php endif; ?>

--- a/panel.php
+++ b/panel.php
@@ -5,7 +5,9 @@ require_once 'image_utils.php';
 require_once 'session.php';
 require_once 'device.php';
 if(!isset($_SESSION['user_id'])){
-    header('Location: login.php');
+    $query = $_SERVER['QUERY_STRING'] ?? '';
+    $target = 'login.php' . ($query ? '?' . $query : '');
+    header('Location: ' . $target);
     exit;
 }
 $user_id = $_SESSION['user_id'];


### PR DESCRIPTION
## Summary
- extraer la URL compartida en Android y reenviarla a panel.php como parámetro `shared`
- conservar el valor de `shared` en las redirecciones del backend y tras el inicio de sesión
- abrir automáticamente el modal de alta en el panel y precargar el campo con el enlace recibido

## Testing
- php -l index.php
- php -l panel.php
- php -l login.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b343074c832c937f04e03b7b32f3