### PR TITLE
Add shared URL validation helper

### DIFF
--- a/login.php
+++ b/login.php
@@ -8,7 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 } elseif (isset($_GET['shared'])) {
     $sharedParam = trim($_GET['shared']);
 }
-if ($sharedParam !== '' && !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
+if (!isValidSharedUrl($sharedParam)) {
     $sharedParam = '';
 }
 

--- a/oauth.php
+++ b/oauth.php
@@ -6,9 +6,9 @@ $provider = $_GET['provider'] ?? '';
 $sharedParam = '';
 if (isset($_GET['shared'])) {
     $sharedParam = trim($_GET['shared']);
-    if ($sharedParam !== '' && !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
-        $sharedParam = '';
-    }
+}
+if (!isValidSharedUrl($sharedParam)) {
+    $sharedParam = '';
 }
 
 if ($provider === 'google') {

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -12,7 +12,7 @@ $stateParam = $_GET['state'] ?? '';
 $expectedState = $_SESSION['oauth_state_token'] ?? '';
 $sharedParam = $_SESSION['oauth_state_shared'] ?? '';
 unset($_SESSION['oauth_state_token'], $_SESSION['oauth_state_shared']);
-if (!is_string($sharedParam) || $sharedParam === '' || !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
+if (!isValidSharedUrl($sharedParam)) {
     $sharedParam = '';
 }
 if (!$expectedState || !$stateParam || !hash_equals($expectedState, $stateParam)) {

--- a/register.php
+++ b/register.php
@@ -8,7 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 } elseif (isset($_GET['shared'])) {
     $sharedParam = trim($_GET['shared']);
 }
-if ($sharedParam !== '' && !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
+if (!isValidSharedUrl($sharedParam)) {
     $sharedParam = '';
 }
 $encodedShared = $sharedParam !== '' ? rawurlencode($sharedParam) : '';

--- a/seleccion_tableros.php
+++ b/seleccion_tableros.php
@@ -11,7 +11,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 } elseif (isset($_GET['shared'])) {
     $sharedParam = trim($_GET['shared']);
 }
-if ($sharedParam !== '' && !filter_var($sharedParam, FILTER_VALIDATE_URL)) {
+if (!isValidSharedUrl($sharedParam)) {
     $sharedParam = '';
 }
 $encodedShared = $sharedParam !== '' ? rawurlencode($sharedParam) : '';


### PR DESCRIPTION
## Summary
- add a reusable `isValidSharedUrl` helper that normalizes Unicode host and path segments before validation
- switch login, registration, OAuth entry/callback, and board selection flows to rely on the helper for the `shared` parameter
- keep existing redirects and forms propagating the sanitized `shared` value unchanged

## Testing
- for file in session.php login.php register.php oauth.php oauth2callback.php seleccion_tableros.php; do php -l "$file" || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68cbaa7e693c832c8b797e379f8f8863