### PR TITLE
Update SHA256 fingerprint for Android asset links

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "com.android.linkaloo",
       "sha256_cert_fingerprints": [
-        "REPLACE_WITH_YOUR_SHA256_CERT_FINGERPRINT"
+        "69:32:D5:82:6E:9B:D1:79:96:48:5D:90:7F:5C:75:4F:42:8F:BD:28:FE:2F:15:AC:FE:25:6C:56:C6:1D:C8:16"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- replace the placeholder SHA256 certificate fingerprint in `.well-known/assetlinks.json` with the provided value for `com.android.linkaloo`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbc1164688832c915e9dcd775ad68c