### PR TITLE
Add Android App Links handling via in-app web dispatcher

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,28 +1,42 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.android.linkaloo">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="Linkaloo">
-         <activity
-             android:name=".ShareReceiverActivity"
-             android:exported="true"
-             android:label="Guardar en Linkaloo">
-             <!-- Un único enlace / texto -->
-             <intent-filter>
+        <activity
+            android:name=".ShareReceiverActivity"
+            android:exported="true"
+            android:label="Guardar en Linkaloo">
+            <!-- Un único enlace / texto -->
+            <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+        </activity>
 
+        <activity
+            android:name=".LinkDispatcherActivity"
+            android:exported="true"
+            android:label="Linkaloo"
+            android:launchMode="singleTop">
             <!-- Abrir enlaces directamente -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                 <data android:scheme="https" android:host="linkaloo.com" />
-                 <data android:scheme="http" android:host="linkaloo.com" />
-             </intent-filter>
-         </activity>
-     </application>
-  </manifest>
+                <data
+                    android:host="linkaloo.com"
+                    android:pathPrefix="/"
+                    android:scheme="https" />
+                <data
+                    android:host="www.linkaloo.com"
+                    android:pathPrefix="/"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/LinkDispatcherActivity.kt
+++ b/LinkDispatcherActivity.kt
@@ -1,0 +1,108 @@
+package com.android.linkaloo
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+
+class LinkDispatcherActivity : AppCompatActivity() {
+
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_link_dispatcher)
+
+        webView = findViewById(R.id.deepLinkWebView)
+        configureWebView()
+
+        if (savedInstanceState != null) {
+            webView.restoreState(savedInstanceState)
+            return
+        }
+
+        val initialUri = intent?.data?.let { normalizeToHttps(it) }
+        if (initialUri == null) {
+            Log.w(TAG, "Deep link intent without data")
+            finish()
+            return
+        }
+
+        webView.loadUrl(initialUri.toString())
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        intent?.data?.let { normalizeToHttps(it) }?.let { webView.loadUrl(it.toString()) }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        webView.saveState(outState)
+    }
+
+    override fun onBackPressed() {
+        if (this::webView.isInitialized && webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    override fun onDestroy() {
+        if (this::webView.isInitialized) {
+            webView.destroy()
+        }
+        super.onDestroy()
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun configureWebView() {
+        val cookieManager = CookieManager.getInstance()
+        cookieManager.setAcceptCookie(true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            cookieManager.setAcceptThirdPartyCookies(webView, true)
+        }
+        with(webView.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            loadsImagesAutomatically = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            loadWithOverviewMode = true
+            useWideViewPort = true
+        }
+        webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(
+                view: WebView?,
+                request: WebResourceRequest?
+            ): Boolean {
+                return false
+            }
+
+            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                return false
+            }
+        }
+    }
+
+    private fun normalizeToHttps(uri: Uri): Uri {
+        return if (uri.scheme.equals("http", ignoreCase = true)) {
+            uri.buildUpon().scheme("https").build()
+        } else {
+            uri
+        }
+    }
+
+    companion object {
+        private const val TAG = "LinkDispatcher"
+    }
+}

--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -12,22 +12,16 @@ class ShareReceiverActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        when (intent?.action) {
-            Intent.ACTION_SEND -> {
-                when (intent.type) {
-                    "text/plain" -> {
-                        val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
-                        sharedText?.let { handleLink(it) }
-                    }
-                    else -> {
-                        val stream = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
-                        stream?.toString()?.let { handleLink(it) }
-                    }
+        if (intent?.action == Intent.ACTION_SEND) {
+            when (intent.type) {
+                "text/plain" -> {
+                    val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
+                    sharedText?.let { handleLink(it) }
                 }
-            }
-            Intent.ACTION_VIEW -> {
-                val data: Uri? = intent.data
-                data?.toString()?.let { handleLink(it) }
+                else -> {
+                    val stream = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+                    stream?.toString()?.let { handleLink(it) }
+                }
             }
         }
 
@@ -54,7 +48,7 @@ class ShareReceiverActivity : AppCompatActivity() {
 
         if (host != null && (host == "linkaloo.com" || host.endsWith(".linkaloo.com"))) {
             Log.d("ShareReceiver", "Opening Linkaloo URL directly: $sharedUrl")
-            startActivity(Intent(Intent.ACTION_VIEW, sharedUri))
+            launchInApp(sharedUri)
             return
         }
 
@@ -62,6 +56,13 @@ class ShareReceiverActivity : AppCompatActivity() {
         val targetUri = Uri.parse("https://linkaloo.com/panel.php").buildUpon()
             .appendQueryParameter("shared", sharedUrl)
             .build()
-        startActivity(Intent(Intent.ACTION_VIEW, targetUri))
+        launchInApp(targetUri)
+    }
+
+    private fun launchInApp(uri: Uri) {
+        val inAppIntent = Intent(this, LinkDispatcherActivity::class.java).apply {
+            data = uri
+        }
+        startActivity(inAppIntent)
     }
 }

--- a/res/layout/activity_link_dispatcher.xml
+++ b/res/layout/activity_link_dispatcher.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/deepLinkWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbarStyle="outsideOverlay" />
+
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add LinkDispatcherActivity with a WebView dispatcher to render Linkaloo pages for verified App Links
- update ShareReceiverActivity to hand off both internal and external URLs to the dispatcher activity
- declare the intent filter for https App Links plus the required internet permission in the manifest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd6652424832cb20f6a75b0f6be3b