### PR TITLE
Sanitize shared URL parameters

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -218,9 +218,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const sharedParam = params.get('shared');
   if (sharedParam && addModal && linkInput) {
     const candidate = sharedParam.trim();
+    const sanitizedCandidate = candidate.replace(/%(?![0-9A-Fa-f]{2})/g, '%25');
     let validUrl = '';
     try {
-      const parsed = new URL(candidate);
+      const parsed = new URL(sanitizedCandidate);
       if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
         validUrl = parsed.toString();
       }


### PR DESCRIPTION
## Summary
- re-escape stray percent symbols in shared URLs before parsing
- ensure only http/https links populate the add modal using the sanitized URL value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc04663038832cb63f537f41a1a750