### PR TITLE
Sanitize query string handling for redirects

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,11 @@
 <?php
 require_once 'session.php';
-$query = $_SERVER['QUERY_STRING'] ?? '';
-$suffix = $query ? '?' . $query : '';
+$queryParams = $_GET;
+$query = '';
+if(!empty($queryParams)){
+    $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+}
+$suffix = $query !== '' ? '?' . $query : '';
 if(isset($_SESSION['user_id'])){
     header('Location: panel.php' . $suffix);
 } else {

--- a/panel.php
+++ b/panel.php
@@ -5,8 +5,12 @@ require_once 'image_utils.php';
 require_once 'session.php';
 require_once 'device.php';
 if(!isset($_SESSION['user_id'])){
-    $query = $_SERVER['QUERY_STRING'] ?? '';
-    $target = 'login.php' . ($query ? '?' . $query : '');
+    $queryParams = $_GET;
+    $query = '';
+    if(!empty($queryParams)){
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+    }
+    $target = 'login.php' . ($query !== '' ? '?' . $query : '');
     header('Location: ' . $target);
     exit;
 }


### PR DESCRIPTION
## Summary
- rebuild redirect query strings in `panel.php` using `http_build_query` to avoid forwarding raw `QUERY_STRING` data
- apply the same reconstruction in `index.php` so both redirect targets preserve encoded parameters safely

## Testing
- php -l panel.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cc08695cec832ca70ec64284b8d907