### PR TITLE
Re-encode shared URL candidate before validation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -218,7 +218,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const sharedParam = params.get('shared');
   if (sharedParam && addModal && linkInput) {
     const candidate = sharedParam.trim();
-    const sanitizedCandidate = candidate.replace(/%(?![0-9A-Fa-f]{2})/g, '%25');
+    const recodedCandidate = encodeURI(candidate).replace(/%25([0-9A-Fa-f]{2})/g, (_, hex) => '%' + hex);
+    const sanitizedCandidate = recodedCandidate.replace(/%(?![0-9A-Fa-f]{2})/g, '%25');
     let validUrl = '';
     try {
       const parsed = new URL(sanitizedCandidate);


### PR DESCRIPTION
## Summary
- re-encode the decoded `shared` parameter so reserved characters such as spaces remain percent-escaped before passing it to `new URL`
- preserve the existing percent sanitisation after re-encoding to keep invalid percent sequences from breaking validation

## Testing
- `node - <<'NODE'
const params = new URLSearchParams('?shared=https%3A%2F%2Fexample.com%2Fhello%2520world');
const sharedParam = params.get('shared');
const candidate = sharedParam.trim();
const recodedCandidate = encodeURI(candidate).replace(/%25([0-9A-Fa-f]{2})/g, (_, hex) => '%' + hex);
const sanitizedCandidate = recodedCandidate.replace(/%(?![0-9A-Fa-f]{2})/g, '%25');
let validUrl = '';
try {
  const parsed = new URL(sanitizedCandidate);
  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
    validUrl = parsed.toString();
  }
} catch (e) {
  console.error('error', e.message);
}
console.log({ sharedParam, candidate, recodedCandidate, sanitizedCandidate, validUrl });
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68cc0d05bff0832c8c59e61542ba4c10