### PR TITLE
Add clipboard paste button to link modal

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -201,6 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const openModalBtns = document.querySelectorAll('.open-modal');
   const addModal = document.querySelector('.add-modal');
   const linkInput = addModal ? addModal.querySelector('.form-link [name="link_url"]') : null;
+  const pasteLinkButton = addModal ? addModal.querySelector('.paste-link-btn') : null;
   if (openModalBtns.length && addModal) {
     const close = () => addModal.classList.remove('show');
     openModalBtns.forEach(btn => {
@@ -237,6 +238,25 @@ document.addEventListener('DOMContentLoaded', () => {
         history.replaceState(null, '', newUrl);
       }
     }
+  }
+
+  if (pasteLinkButton && linkInput) {
+    pasteLinkButton.addEventListener('click', async () => {
+      if (navigator.clipboard && navigator.clipboard.readText) {
+        try {
+          const text = await navigator.clipboard.readText();
+          if (text) {
+            linkInput.value = text.trim();
+            linkInput.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+          try { linkInput.focus(); } catch (_) {}
+        } catch (_) {
+          alert('No se pudo acceder al portapapeles. Pega el enlace manualmente (Ctrl+V).');
+        }
+      } else {
+        alert('Tu navegador no permite pegar automáticamente. Usa Ctrl+V.');
+      }
+    });
   }
 
   document.addEventListener('click', (e) => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -79,6 +79,9 @@ textarea {
 .form-link .select-create{display:flex;flex-direction:column;gap:5px;}
 .form-link .select-create select,
 .form-link .select-create input{flex:1;}
+.form-link .url-input-group{display:flex;gap:5px;width:100%;flex:1 1 100%;align-items:stretch;}
+.form-link .url-input-group input{flex:1 1 auto;min-width:0;}
+.form-link .url-input-group .paste-link-btn{flex:0 0 auto;white-space:nowrap;}
 @media(min-width:601px){
   .form-link{flex-direction:column;align-items:stretch;}
   .form-link input,

--- a/header.php
+++ b/header.php
@@ -64,7 +64,10 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         <div class="control-forms">
             <div class="form-section">
                 <form method="post" class="form-link">
-                    <input type="url" name="link_url" placeholder="Pega aquí el link" required>
+                    <div class="url-input-group">
+                        <input type="url" name="link_url" placeholder="Pega aquí el link" required>
+                        <button type="button" class="paste-link-btn">Pegar link</button>
+                    </div>
                     <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
                     <div class="select-create">
                         <select name="categoria_id">


### PR DESCRIPTION
## Summary
- add a "Pegar link" button next to the URL field inside the create-link modal
- style the new input group so the field and button stay on the same row
- wire the button to read from the clipboard when available and focus the field as a fallback

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cd0ea4b3ec832cbf0df06a9e7d6fa9