### PR TITLE
Ajusta el botón de pegar en el modal móvil

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -93,6 +93,7 @@ textarea {
   .form-link input,
   .form-link select,
   .form-link button{flex:1 1 100%;width:100%;}
+  .form-link .url-input-group .paste-link-btn{width:auto;flex:0 0 auto;padding:10px 14px;font-size:14px;}
 }
 
 @media (min-width:601px){


### PR DESCRIPTION
## Summary
- reduce el ancho del botón "Pegar link" dentro del modal en vista móvil para que comparta línea con el campo de URL

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cd1d886944832cb1ab7f34fad80a05