### PR TITLE
Remove deep link intent filter to prevent share loop

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,14 +15,6 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
-            <!-- Abrir enlaces directamente -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                 <data android:scheme="https" android:host="linkaloo.com" />
-                 <data android:scheme="http" android:host="linkaloo.com" />
-             </intent-filter>
          </activity>
      </application>
   </manifest>


### PR DESCRIPTION
## Summary
- remove the ACTION_VIEW intent filter from ShareReceiverActivity so the app no longer intercepts linkaloo.com URLs, preventing the share loop

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd313ca72c832cad19611a340c5791