### PR TITLE
Improve Android share workflow

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,6 +15,17 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
+            <!-- Apertura directa de enlaces de Linkaloo -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="linkaloo.com" />
+                <data android:scheme="https" android:host="www.linkaloo.com" />
+                <data android:scheme="http" android:host="linkaloo.com" />
+                <data android:scheme="http" android:host="www.linkaloo.com" />
+            </intent-filter>
+
          </activity>
      </application>
   </manifest>

--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -1,7 +1,9 @@
 package com.android.linkaloo
 
+import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.Patterns
@@ -13,26 +15,67 @@ class ShareReceiverActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         when (intent?.action) {
-            Intent.ACTION_SEND -> {
-                when (intent.type) {
-                    "text/plain" -> {
-                        val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
-                        sharedText?.let { handleLink(it) }
-                    }
-                    else -> {
-                        val stream = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
-                        stream?.toString()?.let { handleLink(it) }
-                    }
-                }
-            }
-            Intent.ACTION_VIEW -> {
-                val data: Uri? = intent.data
-                data?.toString()?.let { handleLink(it) }
-            }
+            Intent.ACTION_SEND -> handleSendIntent(intent)
+            Intent.ACTION_SEND_MULTIPLE -> handleSendMultipleIntent(intent)
+            Intent.ACTION_VIEW -> handleViewIntent(intent)
         }
 
         // Redirige a tu Main si procede o muestra una UI ligera
         finish()
+    }
+
+    private fun handleSendIntent(intent: Intent) {
+        val type = intent.type.orEmpty()
+        if (type.startsWith("text/")) {
+            val sharedText = intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+            if (!sharedText.isNullOrBlank()) {
+                handleLink(sharedText)
+                return
+            }
+
+            extractFromClipData(intent.clipData)?.let {
+                handleLink(it)
+                return
+            }
+        }
+
+        val stream = intent.getParcelableUriExtra(Intent.EXTRA_STREAM)
+        if (stream != null) {
+            handleLink(stream.toString())
+            return
+        }
+
+        Log.w("ShareReceiver", "No shareable content found in ACTION_SEND intent")
+    }
+
+    private fun handleSendMultipleIntent(intent: Intent) {
+        val texts = intent.getCharSequenceArrayListExtra(Intent.EXTRA_TEXT)
+        texts?.firstOrNull { it.isNotBlank() }?.toString()?.let {
+            handleLink(it)
+            return
+        }
+
+        extractFromClipData(intent.clipData)?.let {
+            handleLink(it)
+            return
+        }
+
+        val streams = intent.getParcelableUriArrayListExtra(Intent.EXTRA_STREAM)
+        streams?.firstOrNull()?.let {
+            handleLink(it.toString())
+            return
+        }
+
+        Log.w("ShareReceiver", "No shareable content found in ACTION_SEND_MULTIPLE intent")
+    }
+
+    private fun handleViewIntent(intent: Intent) {
+        val data: Uri? = intent.data
+        if (data != null) {
+            handleLink(data.toString())
+        } else {
+            Log.w("ShareReceiver", "ACTION_VIEW intent received without data")
+        }
     }
 
     private fun handleLink(link: String) {
@@ -54,7 +97,7 @@ class ShareReceiverActivity : AppCompatActivity() {
 
         if (host != null && (host == "linkaloo.com" || host.endsWith(".linkaloo.com"))) {
             Log.d("ShareReceiver", "Opening Linkaloo URL directly: $sharedUrl")
-            startActivity(Intent(Intent.ACTION_VIEW, sharedUri))
+            startActivityIfPossible(Intent(Intent.ACTION_VIEW, sharedUri))
             return
         }
 
@@ -62,6 +105,49 @@ class ShareReceiverActivity : AppCompatActivity() {
         val targetUri = Uri.parse("https://linkaloo.com/panel.php").buildUpon()
             .appendQueryParameter("shared", sharedUrl)
             .build()
-        startActivity(Intent(Intent.ACTION_VIEW, targetUri))
+        startActivityIfPossible(Intent(Intent.ACTION_VIEW, targetUri))
+    }
+
+    private fun extractFromClipData(clipData: ClipData?): String? {
+        clipData ?: return null
+        for (index in 0 until clipData.itemCount) {
+            val item = clipData.getItemAt(index)
+            val text = item.text?.toString()
+            if (!text.isNullOrBlank()) {
+                return text
+            }
+            val uriText = item.uri?.toString()
+            if (!uriText.isNullOrBlank()) {
+                return uriText
+            }
+        }
+        return null
+    }
+
+    private fun startActivityIfPossible(intent: Intent) {
+        val resolved = intent.resolveActivity(packageManager)
+        if (resolved != null) {
+            startActivity(intent)
+        } else {
+            Log.e("ShareReceiver", "No activity available to handle intent: $intent")
+        }
+    }
+
+    private fun Intent.getParcelableUriExtra(name: String): Uri? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(name, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(name)
+        }
+    }
+
+    private fun Intent.getParcelableUriArrayListExtra(name: String): List<Uri>? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableArrayListExtra(name, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableArrayListExtra(name)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an intent-filter in the manifest so the receiver can open Linkaloo URLs directly
- expand `ShareReceiverActivity` to handle multiple SEND variants and clip data before forwarding
- guard outgoing VIEW intents with a resolver check to avoid crashes when no browser is available

## Testing
- not run (Android build environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68cd4692eae0832c9061b595ab7a1f9c