### PR TITLE
Handle shared links from external apps

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,7 +12,14 @@
              <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+
+            <!-- Varios elementos de texto (por ejemplo, pestañas agrupadas) -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
             </intent-filter>
 
             <!-- Apertura directa de enlaces de Linkaloo -->


### PR DESCRIPTION
## Summary
- enable the share receiver activity to accept both single and multi-item text shares
- prevent self-recursion when forwarding shared URLs by preferring external browsers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdb2890388832caf0569903784f936