### PR TITLE
Hide paste button on mobile add link modal

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -93,7 +93,8 @@ textarea {
   .form-link input,
   .form-link select,
   .form-link button{flex:1 1 100%;width:100%;}
-  .form-link .url-input-group .paste-link-btn{width:auto;flex:0 0 auto;padding:10px 14px;font-size:14px;}
+  .form-link .url-input-group input{flex:1 1 100%;width:100%;}
+  .form-link .url-input-group .paste-link-btn{display:none;}
 }
 
 @media (min-width:601px){


### PR DESCRIPTION
## Summary
- hide the paste link button inside the add link modal on mobile devices
- expand the URL input to use the full width when the paste button is hidden on small screens

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdb690a9dc832cb7ffdf8c3720b4cc