### PR TITLE
Documenta iconos PWA gestionados fuera del repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 favicon.ico
 img/favicon.png
+img/icon-192.png
+img/icon-512.png
 
 node_modules
 fichas/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Consulta el índice [docs/README.md](docs/README.md) para una visión general de
 - Buscador de enlaces y filtros por tablero.
 - Menú inferior para mover rápidamente un enlace a otro tablero.
 - Botón para compartir por ficha que usa la Web Share API o copia al portapapeles.
+- Recepción de enlaces desde otros navegadores mediante Web Share Target (`share_target.php`).
 - Icono de configuración con acceso a Cookies, Política de cookies, Condiciones de servicio, Política de privacidad y Quiénes somos, todas con contenido estándar.
 - Diseño responsivo: dos columnas en móvil y altura adaptable sin separación vertical.
 - Carga progresiva de enlaces (scroll infinito) a partir de la ficha 18.
@@ -24,7 +25,7 @@ Consulta el índice [docs/README.md](docs/README.md) para una visión general de
 1. Clona el repositorio.
 2. Crea una base de datos MySQL y ejecuta `database.sql`.
 3. Ajusta las credenciales en `config.php`.
-4. Coloca el logo `img/linkaloo_white.png` (y los favicons en el servidor).
+4. Coloca los recursos gráficos (`img/linkaloo_white.png`, `img/logo_linkaloo_blue.png`, `img/favicon.png`, `img/icon-192.png`, `img/icon-512.png` y `favicon.ico`) en el servidor.
 5. Inicia un servidor PHP en la raíz del proyecto (`php -S localhost:8000`).
 
 ## Uso

--- a/assets/main.js
+++ b/assets/main.js
@@ -265,4 +265,12 @@ document.addEventListener('DOMContentLoaded', () => {
       alert.remove();
     }
   });
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/service-worker.js').catch((error) => {
+        console.error('No se pudo registrar el service worker', error);
+      });
+    });
+  }
 });

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -6,6 +6,7 @@ La tabla siguiente resume los puntos de entrada más relevantes; los detalles de
 | Script / Ruta             | Método(s) | Propósito principal |
 |---------------------------|-----------|---------------------|
 | `panel.php`               | `GET`, `POST` | Panel privado; crea enlaces y muestra tableros. |
+| `share_target.php`        | `GET`, `POST` | Normaliza URLs recibidas desde Web Share Target y redirige al panel. |
 | `load_links.php`          | `GET`     | Devuelve enlaces paginados en JSON. |
 | `move_link.php`           | `POST`    | Cambia un enlace de tablero. |
 | `delete_link.php`         | `POST`    | Elimina un enlace. |
@@ -33,6 +34,14 @@ El script:
 2. Extrae metadatos (`scrapeMetadata`) y descarga imágenes (`saveImageFromUrl`).
 3. Limita título y descripción a 50/150 caracteres según el dispositivo (ver `device.php`).
 4. Actualiza la marca `modificado_en` del tablero.
+
+## `share_target.php`
+
+- **Métodos:** `POST` (también acepta `GET`).
+- **Parámetros:**
+  - `url`, `text`, `title` — valores entregados por el navegador al compartir.
+- **Comportamiento:** extrae la primera URL válida de los parámetros, comprueba que sea HTTP/HTTPS con `isValidSharedUrl()` y redirige a `panel.php?shared=...`.
+- Si no encuentra una URL válida, redirige a `panel.php` sin parámetros.
 
 ## `load_links.php`
 

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -72,7 +72,7 @@ Este documento ofrece una visión completa de cómo está organizada la aplicaci
 - `assets/main.js` inicializa iconos Feather, gestiona el carrusel horizontal de tableros, controla el buscador inline y maneja el modal para agregar enlaces.
 - Los botones «Compartir» utilizan la Web Share API cuando está disponible; como alternativa abren AddToAny.
 - El script aplica animaciones progresivas (`IntersectionObserver`) y recorta descripciones largas en función del ancho de pantalla.
-- Desde el panel es posible abrir el modal de creación con un enlace compartido (`?shared=<URL>`); el JavaScript valida el parámetro y precarga el formulario.
+- Desde el panel es posible abrir el modal de creación con un enlace compartido (`?shared=<URL>`); el JavaScript valida el parámetro y precarga el formulario. El archivo `share_target.php` permite que una PWA instalada reciba URLs desde el menú «Compartir» del sistema.
 
 ## Archivos estáticos y layout
 

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -19,7 +19,7 @@ Después del registro, `seleccion_tableros.php` propone una serie de intereses. 
 
 - **Navegación entre tableros:** el carrusel superior permite cambiar rápidamente entre tableros. El botón «Todo» muestra todas las fichas.
 - **Búsqueda y filtros:** usa el icono de lupa para mostrar el buscador. El filtrado es instantáneo sobre las fichas cargadas.
-- **Añadir enlaces:** pulsa el botón «+» para abrir el modal. Introduce la URL y opcionalmente el título o el tablero destino. El sistema extrae título, descripción, favicon e imagen automáticamente y evita duplicados.
+- **Añadir enlaces:** pulsa el botón «+» para abrir el modal. Introduce la URL y opcionalmente el título o el tablero destino. El sistema extrae título, descripción, favicon e imagen automáticamente y evita duplicados. Si instalas la app como PWA en tu móvil, podrás usar el menú «Compartir» de otros navegadores: `share_target.php` recibe la URL y abre el panel con el modal precargado.
 - **Acciones en una ficha:**
   - **Mover** a otro tablero mediante el desplegable.
   - **Compartir** con la Web Share API o AddToAny.

--- a/gitmore
+++ b/gitmore
@@ -1,0 +1,7 @@
+# Archivos binarios que deben subirse manualmente al servidor
+favicon.ico
+img/favicon.png
+img/linkaloo_white.png
+img/logo_linkaloo_blue.png
+img/icon-192.png
+img/icon-512.png

--- a/header.php
+++ b/header.php
@@ -11,8 +11,10 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#1DA1F2">
     <link rel="icon" href="/img/favicon.png" type="image/png">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="manifest" href="/manifest.webmanifest">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rambla:wght@400;700&display=swap" rel="stylesheet">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,32 @@
+{
+  "name": "linkaloo",
+  "short_name": "linkaloo",
+  "description": "Guarda tus enlaces favoritos en tableros personales.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1DA1F2",
+  "icons": [
+    {
+      "src": "/img/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/img/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "share_target": {
+    "action": "/share_target.php",
+    "method": "POST",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(fetch(event.request));
+});

--- a/share_target.php
+++ b/share_target.php
@@ -1,0 +1,53 @@
+<?php
+require_once 'session.php';
+
+function extractSharedUrl(array $values): string
+{
+    foreach ($values as $value) {
+        if (!is_string($value)) {
+            continue;
+        }
+
+        $candidate = trim($value);
+        if ($candidate === '') {
+            continue;
+        }
+
+        if (isValidSharedUrl($candidate)) {
+            return $candidate;
+        }
+
+        if (preg_match('/https?:\/\/[^\s<>"\']+/i', $candidate, $matches)) {
+            $match = rtrim($matches[0], ".,;\"')>]");
+            if (isValidSharedUrl($match)) {
+                return $match;
+            }
+        }
+    }
+
+    return '';
+}
+
+$sharedUrl = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $sharedUrl = extractSharedUrl([
+        $_POST['url'] ?? '',
+        $_POST['text'] ?? '',
+        $_POST['title'] ?? '',
+    ]);
+} else {
+    $sharedUrl = extractSharedUrl([
+        $_GET['url'] ?? '',
+        $_GET['text'] ?? '',
+        $_GET['shared'] ?? '',
+    ]);
+}
+
+if ($sharedUrl === '') {
+    header('Location: panel.php');
+    exit;
+}
+
+header('Location: panel.php?shared=' . rawurlencode($sharedUrl));
+exit;


### PR DESCRIPTION
## Summary
- retirar los iconos PWA binarios del repositorio y declararlos en `gitmore` para que se suban manualmente al servidor
- añadir las rutas a `.gitignore` y ampliar la guía de instalación para documentar todos los recursos gráficos requeridos

## Testing
- php -l share_target.php
- php -l header.php
- node --check assets/main.js
- node --check service-worker.js
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cdb86ea8bc832cb83983d0a93c6e1c