### PR TITLE
Require environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Consulta el índice [docs/README.md](docs/README.md) para una visión general de
 
 1. Clona el repositorio.
 2. Crea una base de datos MySQL y ejecuta `database.sql`.
-3. Ajusta las credenciales en `config.php`.
+3. Configura las variables de entorno descritas en la sección "Variables de entorno".
 4. Coloca los recursos gráficos (`img/linkaloo_white.png`, `img/logo_linkaloo_blue.png`, `img/favicon.png`, `img/icon-192.png`, `img/icon-512.png` y `favicon.ico`) en el servidor.
 5. Inicia un servidor PHP en la raíz del proyecto (`php -S localhost:8000`).
 
@@ -56,6 +56,23 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
   - `npm run lint:css`
 
 
+## Variables de entorno
+
+El proyecto lee la configuración exclusivamente desde variables de entorno. Asegúrate de definirlas antes de iniciar PHP (por ejemplo, en tu panel de hosting o mediante un fichero `.env` si usas un cargador de variables).
+
+| Variable                 | Descripción |
+| ------------------------ | ----------- |
+| `DB_HOST`                | Host del servidor MySQL. |
+| `DB_NAME`                | Nombre de la base de datos. |
+| `DB_USERNAME`            | Usuario con permisos sobre la base de datos. |
+| `DB_PASSWORD`            | Contraseña del usuario de base de datos. |
+| `DB_CHARSET`             | Conjunto de caracteres usado en la conexión (por ejemplo, `utf8mb4`). |
+| `GOOGLE_CLIENT_ID`       | Client ID de OAuth 2.0 para Google. |
+| `GOOGLE_CLIENT_SECRET`   | Client Secret de OAuth 2.0 para Google. |
+| `GOOGLE_REDIRECT_URI`    | URL de callback configurada en Google Cloud. |
+| `RECAPTCHA_SITE_KEY`     | Clave pública de reCAPTCHA v3. |
+| `RECAPTCHA_SECRET_KEY`   | Clave privada de reCAPTCHA v3. |
+
 ## Login con Google
 
 1. Ve a [Google Cloud Console](https://console.cloud.google.com/) y crea un proyecto.
@@ -63,6 +80,6 @@ Cualquier texto puede adaptarse editando los archivos correspondientes.
 3. En **Credentials** crea un **OAuth client ID** de tipo "Web application".
 4. Añade `http://localhost:8000/oauth2callback.php` (el endpoint de backend que maneja el callback OAuth) y `https://linkaloo.com/oauth2callback.php` en **Authorized redirect URIs**.
 5. Copia el *Client ID* y el *Client Secret*.
-6. Define `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` como variables de entorno (no hay fallback en `config.php`).
+6. Define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` como variables de entorno.
 7. Usa el enlace "Google" en `login.php` para autenticarte.
 

--- a/config.php
+++ b/config.php
@@ -1,10 +1,27 @@
 <?php
+
+if (!function_exists('envOrFail')) {
+    /**
+     * Retrieve an environment variable or throw when it's not available.
+     */
+    function envOrFail(string $key): string
+    {
+        $value = getenv($key);
+
+        if ($value === false || $value === '') {
+            throw new \RuntimeException(sprintf('Environment variable %s is not set.', $key));
+        }
+
+        return $value;
+    }
+}
+
 // Database configuration for linkaloo
-$host     = '82.223.84.165';
-$dbname   = 'smartlinks';
-$username = 'smartuserIOn0s';
-$password = 'WMCuxq@ts8s8g8^w';
-$charset  = 'utf8mb4';
+$host     = envOrFail('DB_HOST');
+$dbname   = envOrFail('DB_NAME');
+$username = envOrFail('DB_USERNAME');
+$password = envOrFail('DB_PASSWORD');
+$charset  = envOrFail('DB_CHARSET');
 
 $options = [
     PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
@@ -22,13 +39,11 @@ try {
 }
 
 // Google OAuth configuration
-$googleClientId     = getenv('GOOGLE_CLIENT_ID') ?: '731706222639-8ise1fcsud3mv3552bt7hrck3o7o6n31.apps.googleusercontent.com';
-$googleClientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: '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';
-$googleRedirectUri  = getenv('GOOGLE_REDIRECT_URI') ?: 'https://linkaloo.com/oauth2callback.php';
+$googleClientId     = envOrFail('GOOGLE_CLIENT_ID');
+$googleClientSecret = envOrFail('GOOGLE_CLIENT_SECRET');
+$googleRedirectUri  = envOrFail('GOOGLE_REDIRECT_URI');
 
-// reCAPTCHA v3 configuration (set your keys in environment variables)
-// Use environment variables `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` or
-// fall back to hard-coded keys if provided.
-$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY') ?: '6Lf8pckrAAAAAE5BqEQKcugNtA_34k6-ErygC4vB';
-$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY') ?: '6Lf8pckrAAAAAGdoqnT9mw0PwMzBB9VIuKuxsN-_';
+// reCAPTCHA v3 configuration
+$recaptchaSiteKey   = envOrFail('RECAPTCHA_SITE_KEY');
+$recaptchaSecretKey = envOrFail('RECAPTCHA_SECRET_KEY');
 ?>


### PR DESCRIPTION
## Summary
- remove hard-coded database, Google OAuth, and reCAPTCHA credentials from `config.php`
- load all configuration values from environment variables and throw when any are missing
- document the required environment variables in the README so deployments know what to set

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68ce592f79b4832cb68ba8e7d5f71846