### PR TITLE
Move link creation into dedicated page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -51,7 +51,7 @@ textarea {
   }
 .content {background:#fff;color:#000;padding:20px;}
 
-.open-modal{background:#1DA1F2;color:#fff;border:none;width:50px;height:50px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:36px;margin:0 5px;flex-shrink:0;padding:0;}
+.open-modal{background:#1DA1F2;color:#fff;border:none;width:50px;height:50px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:36px;margin:0 5px;flex-shrink:0;padding:0;text-decoration:none;}
 .open-modal svg{width:24px;height:24px;}
 .add-mobile{display:none;}
 @media (max-width:600px){.add-mobile{display:flex;}.top-menu .menu .add-menu{display:none;}}
@@ -65,6 +65,17 @@ textarea {
 .add-modal-content{background:#fff;color:#000;padding:10px;padding-left:20px;border-radius:20px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
 .add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
+.add-link-page{display:flex;justify-content:center;padding:40px 20px;}
+.add-link-card{background:#fff;color:#000;border-radius:20px;max-width:500px;width:100%;padding:30px 20px;display:flex;flex-direction:column;align-items:stretch;}
+.add-link-card .control-forms{width:100%;}
+.add-link-card .form-section{width:100%;}
+.add-link-card .form-section form{width:100%;}
+.back-to-panel{display:block;margin-top:15px;text-align:center;color:#1DA1F2;text-decoration:none;font-weight:bold;}
+.back-to-panel:hover{text-decoration:underline;}
+@media(max-width:600px){
+  .add-link-page{padding:30px 15px;}
+  .add-link-card{padding:25px 15px;}
+}
 .control-forms{display:flex;flex-direction:column;gap:10px;}
 .control-forms .form-section{display:flex;flex-direction:column;gap:10px;align-items:center;}
 .control-forms .form-section h3{text-align:center;margin:0;color:#6c757d;}

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -44,7 +44,7 @@ la carga de recursos externos como Feather Icons.
 ## Componentes del frontend
 
 - `assets/main.js` controla la interacción del panel: selección de tableros,
-  filtros de búsqueda, apertura del modal para crear enlaces, envío de
+  filtros de búsqueda, navegación y envío de
   formularios AJAX (`move_link.php`, `delete_link.php`), animaciones de entrada y
   funciones de compartición que recurren a la Web Share API o a AddToAny como
   alternativa.
@@ -54,7 +54,7 @@ la carga de recursos externos como Feather Icons.
 
 ## Flujo de creación de enlaces
 
-1. El usuario abre el modal "Guardar link" en `panel.php`.
+1. El usuario abre la vista `nuevo_link.php` desde el botón "+" del encabezado.
 2. Al enviar el formulario se valida o crea la categoría destino.
 3. `panel.php` descarga metadatos (`scrapeMetadata`) y favicons, normaliza la URL
    (`canonicalizeUrl`) y evita duplicados calculando un hash SHA-1.
@@ -86,8 +86,8 @@ el dispositivo).
 
 `ShareReceiverActivity.kt` actúa como *share target*: intercepta enlaces
 compartidos en Android y abre el panel web (`panel.php`) con el parámetro
-`shared=<url>`. De esta forma se reutiliza la lógica del panel para mostrar el
-modal de alta de enlaces con la URL ya rellenada.
+`shared=<url>`. El panel redirige automáticamente a `nuevo_link.php` para
+mostrar el formulario de alta con la URL ya rellenada.
 
 ## Esquema de la base de datos
 

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -7,8 +7,8 @@ la interfaz web.
 
 1. Abre la página `index.php` y accede al enlace de registro o inicio de sesión.
 2. Regístrate con correo y contraseña o autentícate con Google. Si compartiste un
-   enlace desde otra aplicación, el parámetro `shared` se conservará y verás el
-   modal de alta al llegar al panel.
+   enlace desde otra aplicación, el parámetro `shared` se conservará y el panel
+   te llevará directamente a la vista de alta para completar el guardado.
 3. Tras el registro se ofrece un asistente (`seleccion_tableros.php`) para crear
    tableros iniciales a partir de una lista de intereses; puedes omitirlo si
    prefieres comenzar con un lienzo en blanco.
@@ -25,7 +25,7 @@ la interfaz web.
 
 ## Guardar y editar enlaces
 
-1. Haz clic en el botón `+` para abrir el modal de "Guardar link".
+1. Haz clic en el botón `+` para abrir la vista "Guardar link".
 2. Introduce la URL y, opcionalmente, un título personalizado. Puedes elegir un
    tablero existente o crear uno nuevo escribiendo su nombre.
 3. Al guardar, el sistema descarga metadatos, genera una miniatura y evita
@@ -51,4 +51,5 @@ la interfaz web.
 - `assets/main.js` detecta automáticamente móviles para recortar descripciones y
   optimizar la lectura.
 - En Android, la actividad `ShareReceiverActivity` permite enviar un enlace desde
-  otra aplicación y abrir directamente el panel con el modal de alta prellenado.
+  otra aplicación y abrir directamente el panel, que redirige a la vista de alta
+  con el formulario prellenado.

--- a/header.php
+++ b/header.php
@@ -26,14 +26,21 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
     <div class="logo"><a href="/panel.php"><img src="/img/linkaloo_white.png" alt="linkaloo"><!-- Logo file already on server --></a></div>
     <nav>
         <?php if(isset($_SESSION['user_id']) && isset($categorias)): ?>
-            <button type="button" class="open-modal add-mobile" aria-label="Añadir"><i data-feather="plus"></i></button>
+            <?php
+                $addLinkParams = [];
+                if (isset($selectedCat) && $selectedCat) {
+                    $addLinkParams['cat'] = (int) $selectedCat;
+                }
+                $addLinkUrl = '/nuevo_link.php' . ($addLinkParams ? '?' . http_build_query($addLinkParams) : '');
+            ?>
+            <a class="open-modal add-mobile" aria-label="Añadir" href="<?= htmlspecialchars($addLinkUrl, ENT_QUOTES, 'UTF-8') ?>"><i data-feather="plus"></i></a>
         <?php endif; ?>
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">
             <?php if(isset($_SESSION['user_id'])): ?>
                 <?php if(isset($categorias)): ?>
                     <li class="add-menu">
-                        <button type="button" class="open-modal" aria-label="Añadir"><i data-feather="plus"></i></button>
+                        <a class="open-modal" aria-label="Añadir" href="<?= htmlspecialchars($addLinkUrl, ENT_QUOTES, 'UTF-8') ?>"><i data-feather="plus"></i></a>
                     </li>
                 <?php endif; ?>
                 <li><a href="/tableros.php">Tableros</a></li>
@@ -55,31 +62,4 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         </ul>
     </nav>
 </header>
-<?php if(isset($categorias)): ?>
-<div class="add-modal">
-    <div class="add-modal-content" style="padding: 30px;">
-        <button type="button" class="modal-close" aria-label="Cerrar">&times;</button>
-        <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-        <h2 class="modal-title">Añadir tu favolink</h2>
-        <div class="control-forms">
-            <div class="form-section">
-                <form method="post" class="form-link">
-                    <input type="url" name="link_url" placeholder="Pega aquí el link" required>
-                    <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
-                    <div class="select-create">
-                        <select name="categoria_id">
-                            <option value="">Elige el tablero</option>
-                            <?php foreach($categorias as $categoria): ?>
-                                <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)">
-                    </div>
-                    <button type="submit">Guardar favolink</button>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
-<?php endif; ?>
 <div class="content">

--- a/nuevo_link.php
+++ b/nuevo_link.php
@@ -1,0 +1,54 @@
+<?php
+require 'config.php';
+require_once 'session.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$user_id = (int) $_SESSION['user_id'];
+$selectedCat = isset($_GET['cat']) ? (int) $_GET['cat'] : 0;
+
+$stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY modificado_en DESC');
+$stmt->execute([$user_id]);
+$categorias = $stmt->fetchAll();
+
+$sharedPrefill = '';
+if (isset($_GET['shared'])) {
+    $candidate = trim($_GET['shared']);
+    if ($candidate !== '' && isValidSharedUrl($candidate)) {
+        $sharedPrefill = $candidate;
+    }
+}
+
+include 'header.php';
+?>
+<div class="add-link-page">
+    <div class="add-link-card">
+        <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
+        <h2 class="modal-title">Añadir tu favolink</h2>
+        <div class="control-forms">
+            <div class="form-section">
+                <form method="post" action="panel.php" class="form-link">
+                    <input type="url" name="link_url" placeholder="Pega aquí el link" value="<?= htmlspecialchars($sharedPrefill, ENT_QUOTES, 'UTF-8') ?>" required>
+                    <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
+                    <div class="select-create">
+                        <select name="categoria_id">
+                            <option value="">Elige el tablero</option>
+                            <?php foreach ($categorias as $categoria): ?>
+                                <option value="<?= $categoria['id'] ?>" <?= $categoria['id'] == $selectedCat ? 'selected' : '' ?>><?= htmlspecialchars($categoria['nombre']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)">
+                    </div>
+                    <button type="submit">Guardar favolink</button>
+                </form>
+                <a class="back-to-panel" href="panel.php">Volver al panel</a>
+            </div>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>

--- a/panel.php
+++ b/panel.php
@@ -18,6 +18,20 @@ $descLimit = isMobile() ? 50 : 150;
 $error = $_SESSION['panel_error'] ?? '';
 unset($_SESSION['panel_error']);
 
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['shared'])) {
+    $candidate = trim($_GET['shared']);
+    $redirectParams = [];
+    if ($candidate !== '' && isValidSharedUrl($candidate)) {
+        $redirectParams['shared'] = $candidate;
+    }
+    if ($selectedCat) {
+        $redirectParams['cat'] = $selectedCat;
+    }
+    $query = $redirectParams ? '?' . http_build_query($redirectParams) : '';
+    header('Location: nuevo_link.php' . $query);
+    exit;
+}
+
 function ensureUtf8($string){
     $encoding = mb_detect_encoding($string, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
     if($encoding && $encoding !== 'UTF-8'){


### PR DESCRIPTION
## Summary
- replace the add-link modal with navigation to `nuevo_link.php`, keeping the button style and preserving the selected board in the generated link
- add `nuevo_link.php` to host the save-link form, including URL prefill support and a redirect from `panel.php` when a shared link is received
- style the standalone page and update the docs to describe the new workflow

## Testing
- php -l header.php
- php -l panel.php
- php -l nuevo_link.php
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cfe2f6b86c832ca4348951dc36800d