### PR TITLE
Restaurar diseño vertical del formulario de nuevo link

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -65,15 +65,16 @@ textarea {
 .add-modal-content{background:#fff;color:#000;padding:10px;padding-left:20px;border-radius:20px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
 .add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
-.add-link-page{display:flex;justify-content:center;padding:40px 20px;}
-.add-link-card{background:#fff;color:#000;border-radius:20px;max-width:500px;width:100%;padding:30px 20px;display:flex;flex-direction:column;align-items:stretch;}
-.add-link-card .control-forms{width:100%;}
-.add-link-card .form-section{width:100%;}
+.add-link-page{display:flex;justify-content:center;align-items:center;padding:40px 20px;min-height:calc(100vh - 160px);}
+.add-link-card{background:#fff;color:#000;border-radius:20px;max-width:500px;width:100%;padding:30px 20px;display:flex;flex-direction:column;align-items:center;text-align:center;gap:20px;}
+.add-link-card .modal-title{margin:0;color:#1DA1F2;}
+.add-link-card .control-forms{width:100%;display:flex;justify-content:center;}
+.add-link-card .form-section{width:100%;max-width:360px;}
 .add-link-card .form-section form{width:100%;}
 .back-to-panel{display:block;margin-top:15px;text-align:center;color:#1DA1F2;text-decoration:none;font-weight:bold;}
 .back-to-panel:hover{text-decoration:underline;}
 @media(max-width:600px){
-  .add-link-page{padding:30px 15px;}
+  .add-link-page{padding:30px 15px;min-height:calc(100vh - 140px);}
   .add-link-card{padding:25px 15px;}
 }
 .control-forms{display:flex;flex-direction:column;gap:10px;}
@@ -87,7 +88,12 @@ textarea {
 .control-forms select{background:#f0e8e8;color:#000;border:none;border-radius:20px;font-family:'Rambla',sans-serif;}
 .control-forms select option[value=""]{color:#6c757d;}
 
-.form-link .select-create{display:flex;flex-direction:column;gap:5px;}
+.add-link-card .form-link{display:flex;flex-direction:column;gap:12px;align-items:stretch;}
+.add-link-card .form-link input,
+.add-link-card .form-link select,
+.add-link-card .form-link button{width:100%;}
+.add-link-card .form-link button{margin-top:5px;}
+.form-link .select-create{display:flex;flex-direction:column;gap:12px;}
 .form-link .select-create select,
 .form-link .select-create input{flex:1;}
 @media(min-width:601px){

--- a/nuevo_link.php
+++ b/nuevo_link.php
@@ -27,11 +27,11 @@ include 'header.php';
 <div class="add-link-page">
     <div class="add-link-card">
         <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-        <h2 class="modal-title">Añadir tu favolink</h2>
+        <h2 class="modal-title">Añadir link</h2>
         <div class="control-forms">
             <div class="form-section">
                 <form method="post" action="panel.php" class="form-link">
-                    <input type="url" name="link_url" placeholder="Pega aquí el link" value="<?= htmlspecialchars($sharedPrefill, ENT_QUOTES, 'UTF-8') ?>" required>
+                    <input type="url" name="link_url" placeholder="Pega aquí tu link" value="<?= htmlspecialchars($sharedPrefill, ENT_QUOTES, 'UTF-8') ?>" required>
                     <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
                     <div class="select-create">
                         <select name="categoria_id">
@@ -40,7 +40,7 @@ include 'header.php';
                                 <option value="<?= $categoria['id'] ?>" <?= $categoria['id'] == $selectedCat ? 'selected' : '' ?>><?= htmlspecialchars($categoria['nombre']) ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)">
+                        <input type="text" name="categoria_nombre" placeholder="o crea uno nuevo (opcional)">
                     </div>
                     <button type="submit">Guardar favolink</button>
                 </form>


### PR DESCRIPTION
## Summary
- centra verticalmente la tarjeta de creación de favolinks y ajusta la maquetación para que los campos se apilen en columna
- actualiza los textos del formulario para que coincidan con el copy solicitado

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe6d91a00832ca5bc91c8aa82985d