### PR TITLE
Alinear formulario de alta en móvil con el nuevo diseño

### DIFF
--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -59,7 +59,7 @@ class ShareReceiverActivity : AppCompatActivity() {
         }
 
         Log.d("ShareReceiver", "Forwarding shared link: $sharedUrl")
-        val targetUri = Uri.parse("https://linkaloo.com/panel.php").buildUpon()
+        val targetUri = Uri.parse("https://linkaloo.com/nuevo_link.php").buildUpon()
             .appendQueryParameter("shared", sharedUrl)
             .build()
         startActivity(Intent(Intent.ACTION_VIEW, targetUri))

--- a/assets/style.css
+++ b/assets/style.css
@@ -75,7 +75,12 @@ textarea {
 .back-to-panel:hover{text-decoration:underline;}
 @media(max-width:600px){
   .add-link-page{padding:30px 15px;min-height:calc(100vh - 140px);}
-  .add-link-card{padding:25px 15px;}
+  .add-link-card{padding:25px 15px;gap:16px;}
+  .add-link-card .form-section{max-width:100%;}
+  .add-link-card .form-link input,
+  .add-link-card .form-link select,
+  .add-link-card .form-link button{font-size:16px;}
+  .add-link-card .app-logo img{height:72px;}
 }
 .control-forms{display:flex;flex-direction:column;gap:10px;}
 .control-forms .form-section{display:flex;flex-direction:column;gap:10px;align-items:center;}

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -85,9 +85,8 @@ el dispositivo).
 ## Integración con Android
 
 `ShareReceiverActivity.kt` actúa como *share target*: intercepta enlaces
-compartidos en Android y abre el panel web (`panel.php`) con el parámetro
-`shared=<url>`. El panel redirige automáticamente a `nuevo_link.php` para
-mostrar el formulario de alta con la URL ya rellenada.
+compartidos en Android y abre directamente `nuevo_link.php` con el parámetro
+`shared=<url>` para mostrar el formulario de alta con la URL ya rellenada.
 
 ## Esquema de la base de datos
 

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -7,8 +7,8 @@ la interfaz web.
 
 1. Abre la página `index.php` y accede al enlace de registro o inicio de sesión.
 2. Regístrate con correo y contraseña o autentícate con Google. Si compartiste un
-   enlace desde otra aplicación, el parámetro `shared` se conservará y el panel
-   te llevará directamente a la vista de alta para completar el guardado.
+   enlace desde otra aplicación, el parámetro `shared` se conservará y accederás
+   a `nuevo_link.php` para completar el guardado.
 3. Tras el registro se ofrece un asistente (`seleccion_tableros.php`) para crear
    tableros iniciales a partir de una lista de intereses; puedes omitirlo si
    prefieres comenzar con un lienzo en blanco.
@@ -51,5 +51,5 @@ la interfaz web.
 - `assets/main.js` detecta automáticamente móviles para recortar descripciones y
   optimizar la lectura.
 - En Android, la actividad `ShareReceiverActivity` permite enviar un enlace desde
-  otra aplicación y abrir directamente el panel, que redirige a la vista de alta
-  con el formulario prellenado.
+  otra aplicación y abre directamente `nuevo_link.php` con el formulario
+  prellenado.


### PR DESCRIPTION
## Summary
- Actualicé ShareReceiverActivity para que abra directamente `nuevo_link.php`, mostrando el formulario con el nuevo diseño cuando se comparte desde Android.
- Ajusté los estilos de `assets/style.css` para que la vista móvil del formulario conserve la separación, tipografía y escala introducidas en escritorio.
- Actualicé la documentación de integración y uso para describir el flujo móvil tras el cambio.

## Testing
- php -l config.php panel.php move_link.php load_links.php
- node --check assets/main.js
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cff004afac832cb90ae32b36d44ec2