### PR TITLE
Move favolink creation to dedicated page

### DIFF
--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -59,7 +59,7 @@ class ShareReceiverActivity : AppCompatActivity() {
         }
 
         Log.d("ShareReceiver", "Forwarding shared link: $sharedUrl")
-        val targetUri = Uri.parse("https://linkaloo.com/panel.php").buildUpon()
+        val targetUri = Uri.parse("https://linkaloo.com/agregar_favolink.php").buildUpon()
             .appendQueryParameter("shared", sharedUrl)
             .build()
         startActivity(Intent(Intent.ACTION_VIEW, targetUri))

--- a/agregar_favolink.php
+++ b/agregar_favolink.php
@@ -1,0 +1,198 @@
+<?php
+require 'config.php';
+require 'favicon_utils.php';
+require_once 'image_utils.php';
+require_once 'session.php';
+require_once 'device.php';
+
+if(!isset($_SESSION['user_id'])){
+    $query = $_SERVER['QUERY_STRING'] ?? '';
+    $target = 'login.php' . ($query ? '?' . $query : '');
+    header('Location: ' . $target);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+$descLimit = isMobile() ? 50 : 150;
+
+$formValues = [
+    'link_url' => '',
+    'link_title' => '',
+    'categoria_id' => '',
+    'categoria_nombre' => '',
+];
+
+if(isset($_GET['shared'])){
+    $sharedParam = trim($_GET['shared']);
+    if(isValidSharedUrl($sharedParam)){
+        $formValues['link_url'] = $sharedParam;
+    }
+}
+
+function ensureUtf8($string){
+    $encoding = mb_detect_encoding($string, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
+    if($encoding && $encoding !== 'UTF-8'){
+        $string = mb_convert_encoding($string, 'UTF-8', $encoding);
+    }
+    return $string;
+}
+
+function canonicalizeUrl($url){
+    $parts = parse_url(trim($url));
+    if(!$parts || empty($parts['host'])){
+        return $url;
+    }
+    $scheme = strtolower($parts['scheme'] ?? 'http');
+    $host = strtolower($parts['host']);
+    $path = isset($parts['path']) ? rtrim($parts['path'], '/') : '';
+    $query = isset($parts['query']) ? '?' . $parts['query'] : '';
+    $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+    return $scheme . '://' . $host . $port . $path . $query;
+}
+
+function scrapeMetadata($url){
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; linkalooBot/1.0)',
+        CURLOPT_TIMEOUT => 5,
+    ]);
+    $html = curl_exec($ch);
+    curl_close($ch);
+    if(!$html){
+        return [];
+    }
+    $enc = mb_detect_encoding($html, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
+    if($enc){
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', $enc);
+    }
+    libxml_use_internal_errors(true);
+    $doc = new DOMDocument();
+    $doc->loadHTML($html);
+    $xpath = new DOMXPath($doc);
+    $getMeta = function($name, $attr='property') use ($xpath){
+        $nodes = $xpath->query("//meta[@$attr='$name']/@content");
+        return $nodes->length ? trim($nodes->item(0)->nodeValue) : '';
+    };
+    $meta = [];
+    $titles = $doc->getElementsByTagName('title');
+    if($titles->length){
+        $meta['title'] = trim($titles->item(0)->textContent);
+    }
+    $meta['description'] = $getMeta('og:description') ?: $getMeta('description','name');
+    $meta['image'] = $getMeta('og:image') ?: $getMeta('twitter:image');
+    if(!empty($meta['image']) && !preg_match('#^https?://#', $meta['image'])){
+        $parts = parse_url($url);
+        $base = $parts['scheme'].'://'.$parts['host'];
+        if(isset($parts['port'])){
+            $base .= ':'.$parts['port'];
+        }
+        $meta['image'] = rtrim($base,'/').'/'.ltrim($meta['image'],'/');
+    }
+    foreach($meta as &$value){
+        $value = ensureUtf8($value);
+    }
+    unset($value);
+    return $meta;
+}
+
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    $link_url = trim($_POST['link_url'] ?? '');
+    $link_title = trim($_POST['link_title'] ?? '');
+    $categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 0;
+    $categoria_nombre = trim($_POST['categoria_nombre'] ?? '');
+
+    $formValues['link_url'] = $link_url;
+    $formValues['link_title'] = $link_title;
+    $formValues['categoria_id'] = $categoria_id ? (string)$categoria_id : '';
+    $formValues['categoria_nombre'] = $categoria_nombre;
+
+    if($categoria_nombre){
+        $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
+        $stmt->execute([$user_id, $categoria_nombre]);
+        $categoria_id = (int)$pdo->lastInsertId();
+    }
+
+    if($link_url && $categoria_id){
+        $meta = scrapeMetadata($link_url);
+        if(!$link_title && !empty($meta['title'])){
+            $link_title = $meta['title'];
+        }
+        $link_title = ensureUtf8($link_title);
+        if (mb_strlen($link_title) > 50) {
+            $link_title = mb_substr($link_title, 0, 47) . '...';
+        }
+        $descripcion = ensureUtf8($meta['description'] ?? '');
+        if (mb_strlen($descripcion) > $descLimit) {
+            $descripcion = mb_substr($descripcion, 0, $descLimit - 3) . '...';
+        }
+        $imagen = $meta['image'] ?? '';
+        if (empty($imagen)) {
+            $domain = parse_url($link_url, PHP_URL_HOST);
+            if ($domain) {
+                $imagen = getLocalFavicon($domain);
+            }
+        }
+        if(!empty($imagen) && str_starts_with($imagen, 'http')){
+            $localImg = saveImageFromUrl($imagen, $user_id);
+            if($localImg){
+                $imagen = $localImg;
+            }
+        }
+        $canon = canonicalizeUrl($link_url);
+        $hash = sha1($canon);
+        $check = $pdo->prepare('SELECT id FROM links WHERE usuario_id = ? AND hash_url = ?');
+        $check->execute([$user_id, $hash]);
+        if($check->fetch()){
+            $_SESSION['panel_error'] = 'Este link ya está guardado.';
+        } else {
+            $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, url_canonica, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt->execute([$user_id, $categoria_id, $link_url, $canon, $link_title, $descripcion, $imagen, $hash]);
+            if ($stmt->rowCount()) {
+                $upd = $pdo->prepare('UPDATE categorias SET modificado_en = NOW() WHERE id = ?');
+                $upd->execute([$categoria_id]);
+            }
+        }
+    }
+
+    header('Location: panel.php');
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY modificado_en DESC');
+$stmt->execute([$user_id]);
+$categorias = $stmt->fetchAll();
+
+include 'header.php';
+?>
+<div class="favolink-page">
+    <div class="favolink-card">
+        <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
+        <p class="favolink-tagline">Yours favolinks with superpowers</p>
+        <h2 class="modal-title">Añadir tu favolink</h2>
+        <div class="control-forms">
+            <div class="form-section">
+                <form method="post" class="form-link favolink-form">
+                    <input type="url" name="link_url" placeholder="Pega aquí el link" value="<?= htmlspecialchars($formValues['link_url']) ?>" required>
+                    <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50" value="<?= htmlspecialchars($formValues['link_title']) ?>">
+                    <div class="select-create">
+                        <select name="categoria_id">
+                            <option value="">Elige el tablero</option>
+                            <?php foreach($categorias as $categoria): ?>
+                                <option value="<?= $categoria['id'] ?>" <?= ($formValues['categoria_id'] !== '' && (int)$formValues['categoria_id'] === (int)$categoria['id']) ? 'selected' : '' ?>>
+                                    <?= htmlspecialchars($categoria['nombre']) ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)" value="<?= htmlspecialchars($formValues['categoria_nombre']) ?>">
+                    </div>
+                    <button type="submit">Guardar favolink</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>

--- a/assets/main.js
+++ b/assets/main.js
@@ -198,43 +198,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  const openModalBtns = document.querySelectorAll('.open-modal');
-  const addModal = document.querySelector('.add-modal');
-  const linkInput = addModal ? addModal.querySelector('.form-link [name="link_url"]') : null;
-  if (openModalBtns.length && addModal) {
-    const close = () => addModal.classList.remove('show');
-    openModalBtns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        addModal.classList.add('show');
-      });
-    });
-    addModal.addEventListener('click', (e) => {
-      if (e.target === addModal || e.target.classList.contains('modal-close')) {
-        close();
+  const favolinkForm = document.querySelector('.favolink-form');
+  if (favolinkForm) {
+    const linkInput = favolinkForm.querySelector('[name="link_url"]');
+    if (linkInput) {
+      const sharedParam = params.get('shared');
+      if (sharedParam) {
+        try { linkInput.focus(); } catch (_) {}
       }
-    });
-  }
-
-  const sharedParam = params.get('shared');
-  if (sharedParam && addModal && linkInput) {
-    const candidate = sharedParam.trim();
-    let validUrl = '';
-    try {
-      const parsed = new URL(candidate);
-      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-        validUrl = parsed.toString();
-      }
-    } catch (_) {}
-
-    if (validUrl) {
-      linkInput.value = validUrl;
-      addModal.classList.add('show');
-      try { linkInput.focus(); } catch (_) {}
-      params.delete('shared');
-      if (typeof history.replaceState === 'function') {
-        const newQuery = params.toString();
-        const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash}`;
-        history.replaceState(null, '', newUrl);
+      if (params.has('shared')) {
+        params.delete('shared');
+        if (typeof history.replaceState === 'function') {
+          const newQuery = params.toString();
+          const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash}`;
+          history.replaceState(null, '', newUrl);
+        }
       }
     }
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -51,8 +51,11 @@ textarea {
   }
 .content {background:#fff;color:#000;padding:20px;}
 
-.open-modal{background:#1DA1F2;color:#fff;border:none;width:50px;height:50px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:36px;margin:0 5px;flex-shrink:0;padding:0;}
-.open-modal svg{width:24px;height:24px;}
+.open-modal,
+.add-link-btn{background:#1DA1F2;color:#fff;border:none;width:50px;height:50px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:36px;margin:0 5px;flex-shrink:0;padding:0;text-decoration:none;}
+.open-modal svg,
+.add-link-btn svg{width:24px;height:24px;}
+.add-link-btn{border-radius:50%;}
 .add-mobile{display:none;}
 @media (max-width:600px){.add-mobile{display:flex;}.top-menu .menu .add-menu{display:none;}}
 .search-toggle{background:#fff;color:#1DA1F2;border:none;border-radius:4px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:20px;margin-left:5px;flex-shrink:0;}
@@ -64,7 +67,12 @@ textarea {
 .add-modal.show{display:flex;}
 .add-modal-content{background:#fff;color:#000;padding:10px;padding-left:20px;border-radius:20px;max-width:500px;width:100%;position:relative;max-height:100%;overflow:auto;}
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
-.add-modal-content h2.modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
+.add-modal-content h2.modal-title,
+.favolink-card .modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
+.favolink-page{min-height:calc(100vh - 80px);display:flex;align-items:center;justify-content:center;padding:40px 20px;background:#f5f8fa;}
+.favolink-card{background:#fff;color:#000;border-radius:20px;max-width:480px;width:100%;padding:35px 30px;box-shadow:0 10px 25px rgba(0,0,0,0.1);}
+.favolink-tagline{text-align:center;margin:0 0 10px;color:#1DA1F2;font-weight:700;}
+.favolink-card .control-forms{margin-top:10px;}
 .control-forms{display:flex;flex-direction:column;gap:10px;}
 .control-forms .form-section{display:flex;flex-direction:column;gap:10px;align-items:center;}
 .control-forms .form-section h3{text-align:center;margin:0;color:#6c757d;}

--- a/docs/manual_tecnico.md
+++ b/docs/manual_tecnico.md
@@ -6,10 +6,10 @@ Linkaloo es una aplicación web que permite guardar enlaces en tableros temátic
 
 ## Arquitectura general
 
-- **Presentación:** las vistas HTML se generan desde scripts PHP como `panel.php`, `tableros.php`, `tablero.php`, `login.php` y `register.php`, que incluyen `header.php` para compartir el encabezado, los recursos estáticos y el modal de creación de enlaces.【F:panel.php†L1-L112】【F:header.php†L1-L74】
+- **Presentación:** las vistas HTML se generan desde scripts PHP como `panel.php`, `tableros.php`, `tablero.php`, `login.php` y `register.php`, que incluyen `header.php` para compartir el encabezado y los recursos estáticos; el formulario de alta se ofrece en la página dedicada `agregar_favolink.php`, reutilizando la misma cabecera.【F:panel.php†L1-L40】【F:header.php†L10-L36】【F:agregar_favolink.php†L1-L112】
 - **Capa de aplicación:** la lógica de negocio vive en los mismos scripts PHP e incorpora funciones auxiliares para normalizar URL, extraer metadatos y evitar duplicados. Otros scripts dedicados (`move_link.php`, `delete_link.php`, `load_links.php`) actúan como endpoints JSON que reciben peticiones asíncronas desde el cliente.【F:panel.php†L24-L123】【F:move_link.php†L1-L24】【F:delete_link.php†L1-L24】【F:load_links.php†L1-L33】
 - **Persistencia:** todos los datos se almacenan en una base MySQL definida en `database.sql`. El acceso se realiza mediante PDO con consultas preparadas centralizadas en `config.php`, donde también se inicializa la conexión y se cargan claves de OAuth y reCAPTCHA desde variables de entorno.【F:config.php†L1-L35】【F:database.sql†L1-L44】
-- **Clientes externos:** el repositorio incluye un receptor Android (`ShareReceiverActivity.kt`) que permite compartir URLs del sistema operativo hacia la aplicación web inyectando el parámetro `shared` en `panel.php` al abrirse.【F:ShareReceiverActivity.kt†L1-L55】
+- **Clientes externos:** el repositorio incluye un receptor Android (`ShareReceiverActivity.kt`) que permite compartir URLs del sistema operativo hacia la aplicación web inyectando el parámetro `shared` en `agregar_favolink.php` al abrirse.【F:ShareReceiverActivity.kt†L1-L58】
 
 ## Directorios principales
 
@@ -26,12 +26,12 @@ Linkaloo es una aplicación web que permite guardar enlaces en tableros temátic
 
 1. **Registro y login manual:** `register.php` y `login.php` verifican Google reCAPTCHA v3 antes de crear o validar credenciales. Las contraseñas se almacenan con `password_hash` y las sesiones se regeneran tras autenticarse.【F:register.php†L16-L52】【F:login.php†L22-L47】
 2. **Recordar sesión:** `session.php` configura una vida útil de 365 días y emite cookies de “remember me” basadas en selectores y validadores almacenados en `usuario_tokens`. Las funciones `linkalooIssueRememberMeToken`, `linkalooAttemptAutoLogin` y `linkalooClearRememberMeToken` encapsulan este ciclo.【F:session.php†L1-L143】
-3. **OAuth con Google:** `oauth.php` construye la URL de autorización con un token `state`, mientras que `oauth2callback.php` intercambia el `code` por tokens, obtiene el perfil y crea o actualiza al usuario antes de iniciar sesión. El parámetro opcional `shared` se conserva para precargar el modal de alta de enlaces tras el login.【F:oauth.php†L1-L32】【F:oauth2callback.php†L1-L75】
+3. **OAuth con Google:** `oauth.php` construye la URL de autorización con un token `state`, mientras que `oauth2callback.php` intercambia el `code` por tokens, obtiene el perfil y crea o actualiza al usuario antes de iniciar sesión. El parámetro opcional `shared` se conserva para precargar la vista `agregar_favolink.php` tras el login.【F:oauth.php†L1-L32】【F:oauth2callback.php†L1-L85】【F:agregar_favolink.php†L1-L112】
 4. **Gestión de cuenta:** `cpanel.php` permite editar nombre y correo; `cambiar_password.php` valida la contraseña actual antes de actualizarla; `recuperar_password.php` y `restablecer_password.php` gestionan tokens temporales de recuperación almacenados en `password_resets`; `logout.php` destruye la sesión y revoca el token persistente.【F:cpanel.php†L1-L45】【F:cambiar_password.php†L1-L36】【F:recuperar_password.php†L1-L26】【F:restablecer_password.php†L1-L40】【F:logout.php†L1-L16】
 
 ## Gestión de tableros y enlaces
 
-- **Creación y listado:** `panel.php` carga las categorías del usuario, muestra un modal para añadir enlaces y filtra por tablero. Al guardar un enlace, normaliza la URL (`canonicalizeUrl`), descarga metadatos (`scrapeMetadata`), recorta títulos y descripciones según el dispositivo y evita duplicados mediante un `hash_url`. Si el usuario introduce un nombre nuevo de tablero, se crea automáticamente.【F:panel.php†L24-L123】
+- **Creación y listado:** `panel.php` carga las categorías del usuario, filtra por tablero y muestra las tarjetas de enlaces, mientras que `agregar_favolink.php` gestiona la inserción normalizando la URL (`canonicalizeUrl`), extrayendo metadatos (`scrapeMetadata`), truncando textos según dispositivo y evitando duplicados con `hash_url`; si el usuario indica un tablero nuevo, se crea automáticamente.【F:panel.php†L1-L120】【F:agregar_favolink.php†L1-L112】
 - **Movimientos y borrado:** las tarjetas incluyen un desplegable para mover enlaces entre tableros. Esta acción dispara `move_link.php`, que valida la autoría y actualiza la marca `modificado_en`. Los borrados usan `delete_link.php` con lógica similar.【F:move_link.php†L1-L24】【F:delete_link.php†L1-L24】
 - **Administración de tableros:** `tableros.php` lista tableros con recuento de enlaces y botones para compartirlos. `tablero.php` permite renombrar, añadir notas, activar un token público (`share_token`), regenerar imágenes automáticamente y eliminar tableros completos. También muestra métricas de creación y modificación.【F:tableros.php†L1-L67】【F:tablero.php†L1-L128】
 - **Edición detallada:** `editar_link.php` abre una ficha individual para actualizar título y nota, además de permitir su eliminación directa desde la vista detallada.【F:editar_link.php†L1-L53】
@@ -44,7 +44,7 @@ El archivo `assets/main.js` enriquece la navegación con JavaScript progresivo:
 
 - Inicializa iconos Feather y gestiona el menú responsive. Controla el carrusel de tableros superior, guardando el desplazamiento horizontal en `sessionStorage` y filtrando tarjetas según la categoría activa.【F:assets/main.js†L1-L66】
 - Implementa búsqueda en vivo, comparte enlaces usando la Web Share API (con fallback a AddToAny) y sincroniza el desplegable de movimiento con la vista cuando el servidor confirma el cambio.【F:assets/main.js†L67-L127】
-- Observa las tarjetas para animarlas al entrar en pantalla, limita la longitud de las descripciones según el ancho del dispositivo y abre el modal de creación, incluyendo el autoprefill cuando se recibe un parámetro `shared` en la URL.【F:assets/main.js†L129-L207】
+- Observa las tarjetas para animarlas al entrar en pantalla, limita la longitud de las descripciones según el ancho del dispositivo y limpia el parámetro `shared` enfocando el formulario de `agregar_favolink.php` cuando está presente.【F:assets/main.js†L129-L214】
 - Maneja los botones de borrado en la vista detallada y cierra avisos de error con delegación de eventos.【F:assets/main.js†L129-L207】
 
 ## Endpoints y utilidades de soporte
@@ -68,7 +68,7 @@ La estructura definida en `database.sql` contempla cinco tablas principales:【F
 - **Google OAuth y reCAPTCHA:** se configuran mediante las variables de entorno `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `RECAPTCHA_SITE_KEY` y `RECAPTCHA_SECRET_KEY`, con valores de respaldo en `config.php`.【F:config.php†L21-L34】
 - **Web Share API y AddToAny:** la interfaz usa la API nativa cuando está disponible; en su defecto abre AddToAny con los parámetros adecuados.【F:assets/main.js†L67-L126】
 - **Favicons de Google y redimensionado GD:** `favicon_utils.php` y `image_utils.php` dependen de cURL y la extensión GD para descargar y ajustar imágenes a tamaños consistentes.【F:image_utils.php†L16-L46】【F:favicon_utils.php†L16-L31】
-- **Aplicación Android:** `ShareReceiverActivity` y `AndroidManifest.xml` habilitan compartir texto/URL desde Android y abren Linkaloo con la URL enviada, añadiendo el parámetro `shared` cuando procede.【F:ShareReceiverActivity.kt†L10-L55】【F:AndroidManifest.xml†L1-L25】
+- **Aplicación Android:** `ShareReceiverActivity` y `AndroidManifest.xml` habilitan compartir texto/URL desde Android y abren Linkaloo con la URL enviada, añadiendo el parámetro `shared` cuando procede.【F:ShareReceiverActivity.kt†L10-L58】【F:AndroidManifest.xml†L1-L25】
 
 ## Configuración y comprobaciones
 

--- a/header.php
+++ b/header.php
@@ -26,14 +26,14 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
     <div class="logo"><a href="/panel.php"><img src="/img/linkaloo_white.png" alt="linkaloo"><!-- Logo file already on server --></a></div>
     <nav>
         <?php if(isset($_SESSION['user_id']) && isset($categorias)): ?>
-            <button type="button" class="open-modal add-mobile" aria-label="Añadir"><i data-feather="plus"></i></button>
+            <a href="/agregar_favolink.php" class="add-link-btn add-mobile" aria-label="Añadir"><i data-feather="plus"></i></a>
         <?php endif; ?>
         <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
         <ul class="menu">
             <?php if(isset($_SESSION['user_id'])): ?>
                 <?php if(isset($categorias)): ?>
                     <li class="add-menu">
-                        <button type="button" class="open-modal" aria-label="Añadir"><i data-feather="plus"></i></button>
+                        <a href="/agregar_favolink.php" class="add-link-btn" aria-label="Añadir"><i data-feather="plus"></i></a>
                     </li>
                 <?php endif; ?>
                 <li><a href="/tableros.php">Tableros</a></li>
@@ -55,31 +55,4 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         </ul>
     </nav>
 </header>
-<?php if(isset($categorias)): ?>
-<div class="add-modal">
-    <div class="add-modal-content" style="padding: 30px;">
-        <button type="button" class="modal-close" aria-label="Cerrar">&times;</button>
-        <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-        <h2 class="modal-title">Añadir tu favolink</h2>
-        <div class="control-forms">
-            <div class="form-section">
-                <form method="post" class="form-link">
-                    <input type="url" name="link_url" placeholder="Pega aquí el link" required>
-                    <input type="text" name="link_title" placeholder="Título (opcional)" maxlength="50">
-                    <div class="select-create">
-                        <select name="categoria_id">
-                            <option value="">Elige el tablero</option>
-                            <?php foreach($categorias as $categoria): ?>
-                                <option value="<?= $categoria['id'] ?>"><?= htmlspecialchars($categoria['nombre']) ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                        <input type="text" name="categoria_nombre" placeholder="o crea un nuevo (opcional)">
-                    </div>
-                    <button type="submit">Guardar favolink</button>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
-<?php endif; ?>
 <div class="content">

--- a/login.php
+++ b/login.php
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 linkalooIssueRememberMeToken($pdo, (int) $user['id']);
                 $redirect = 'panel.php';
                 if ($sharedParam !== '') {
-                    $redirect .= '?shared=' . rawurlencode($sharedParam);
+                    $redirect = 'agregar_favolink.php?shared=' . rawurlencode($sharedParam);
                 }
                 header('Location: ' . $redirect);
                 exit;

--- a/oauth2callback.php
+++ b/oauth2callback.php
@@ -80,7 +80,7 @@ if ($user) {
     $_SESSION['user_id']   = $userId;
     $_SESSION['user_name'] = $userName;
     linkalooIssueRememberMeToken($pdo, $userId);
-    $redirect = 'panel.php' . ($encodedShared ? '?shared=' . $encodedShared : '');
+    $redirect = $encodedShared ? 'agregar_favolink.php?shared=' . $encodedShared : 'panel.php';
     header('Location: ' . $redirect);
     exit;
 } else {

--- a/panel.php
+++ b/panel.php
@@ -1,7 +1,6 @@
 <?php
 require 'config.php';
 require 'favicon_utils.php';
-require_once 'image_utils.php';
 require_once 'session.php';
 require_once 'device.php';
 if(!isset($_SESSION['user_id'])){
@@ -18,131 +17,14 @@ $descLimit = isMobile() ? 50 : 150;
 $error = $_SESSION['panel_error'] ?? '';
 unset($_SESSION['panel_error']);
 
-function ensureUtf8($string){
-    $encoding = mb_detect_encoding($string, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
-    if($encoding && $encoding !== 'UTF-8'){
-        $string = mb_convert_encoding($string, 'UTF-8', $encoding);
+if(isset($_GET['shared'])){
+    $sharedIncoming = trim($_GET['shared']);
+    if(isValidSharedUrl($sharedIncoming)){
+        $redirect = 'agregar_favolink.php?shared=' . rawurlencode($sharedIncoming);
+        header('Location: ' . $redirect);
+        exit;
     }
-    return $string;
 }
-
-function canonicalizeUrl($url){
-    $parts = parse_url(trim($url));
-    if(!$parts || empty($parts['host'])){
-        return $url;
-    }
-    $scheme = strtolower($parts['scheme'] ?? 'http');
-    $host = strtolower($parts['host']);
-    $path = isset($parts['path']) ? rtrim($parts['path'], '/') : '';
-    $query = isset($parts['query']) ? '?' . $parts['query'] : '';
-    $port = isset($parts['port']) ? ':' . $parts['port'] : '';
-    return $scheme . '://' . $host . $port . $path . $query;
-}
-
-function scrapeMetadata($url){
-    $ch = curl_init($url);
-    curl_setopt_array($ch, [
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; linkalooBot/1.0)',
-        CURLOPT_TIMEOUT => 5,
-    ]);
-    $html = curl_exec($ch);
-    curl_close($ch);
-    if(!$html){
-        return [];
-    }
-    $enc = mb_detect_encoding($html, 'UTF-8, ISO-8859-1, WINDOWS-1252', true);
-    if($enc){
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', $enc);
-    }
-    libxml_use_internal_errors(true);
-    $doc = new DOMDocument();
-    $doc->loadHTML($html);
-    $xpath = new DOMXPath($doc);
-    $getMeta = function($name, $attr='property') use ($xpath){
-        $nodes = $xpath->query("//meta[@$attr='$name']/@content");
-        return $nodes->length ? trim($nodes->item(0)->nodeValue) : '';
-    };
-    $meta = [];
-    $titles = $doc->getElementsByTagName('title');
-    if($titles->length){
-        $meta['title'] = trim($titles->item(0)->textContent);
-    }
-    $meta['description'] = $getMeta('og:description') ?: $getMeta('description','name');
-    $meta['image'] = $getMeta('og:image') ?: $getMeta('twitter:image');
-    if(!empty($meta['image']) && !preg_match('#^https?://#', $meta['image'])){
-        $parts = parse_url($url);
-        $base = $parts['scheme'].'://'.$parts['host'];
-        if(isset($parts['port'])){
-            $base .= ':'.$parts['port'];
-        }
-        $meta['image'] = rtrim($base,'/').'/'.ltrim($meta['image'],'/');
-    }
-    foreach($meta as &$value){
-        $value = ensureUtf8($value);
-    }
-    unset($value);
-    return $meta;
-}
-
-if($_SERVER['REQUEST_METHOD'] === 'POST'){
-    if(isset($_POST['link_url'])){
-        $link_url = trim($_POST['link_url']);
-        $link_title = trim($_POST['link_title']);
-        $categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 0;
-        $categoria_nombre = trim($_POST['categoria_nombre'] ?? '');
-        if($categoria_nombre){
-            $stmt = $pdo->prepare('INSERT INTO categorias (usuario_id, nombre) VALUES (?, ?)');
-            $stmt->execute([$user_id, $categoria_nombre]);
-            $categoria_id = (int)$pdo->lastInsertId();
-        }
-        if($link_url && $categoria_id){
-            $meta = scrapeMetadata($link_url);
-            if(!$link_title && !empty($meta['title'])){
-                $link_title = $meta['title'];
-            }
-            $link_title = ensureUtf8($link_title);
-            if (mb_strlen($link_title) > 50) {
-                $link_title = mb_substr($link_title, 0, 47) . '...';
-            }
-            $descripcion = ensureUtf8($meta['description'] ?? '');
-            if (mb_strlen($descripcion) > $descLimit) {
-                $descripcion = mb_substr($descripcion, 0, $descLimit - 3) . '...';
-            }
-            $imagen = $meta['image'] ?? '';
-            if (empty($imagen)) {
-                $domain = parse_url($link_url, PHP_URL_HOST);
-                if ($domain) {
-                    $imagen = getLocalFavicon($domain);
-                }
-            }
-            if(!empty($imagen) && str_starts_with($imagen, 'http')){
-                $localImg = saveImageFromUrl($imagen, $user_id);
-                if($localImg){
-                    $imagen = $localImg;
-                }
-            }
-            $canon = canonicalizeUrl($link_url);
-            $hash = sha1($canon);
-            $check = $pdo->prepare('SELECT id FROM links WHERE usuario_id = ? AND hash_url = ?');
-            $check->execute([$user_id, $hash]);
-            if($check->fetch()){
-                $_SESSION['panel_error'] = 'Este link ya está guardado.';
-            } else {
-                $stmt = $pdo->prepare('INSERT INTO links (usuario_id, categoria_id, url, url_canonica, titulo, descripcion, imagen, hash_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
-                $stmt->execute([$user_id, $categoria_id, $link_url, $canon, $link_title, $descripcion, $imagen, $hash]);
-                if ($stmt->rowCount()) {
-                    $upd = $pdo->prepare('UPDATE categorias SET modificado_en = NOW() WHERE id = ?');
-                    $upd->execute([$categoria_id]);
-                }
-            }
-        }
-    }
-    header('Location: panel.php');
-    exit;
-}
-
 $stmt = $pdo->prepare('SELECT id, nombre FROM categorias WHERE usuario_id = ? ORDER BY modificado_en DESC');
 $stmt->execute([$user_id]);
 $categorias = $stmt->fetchAll();

--- a/seleccion_tableros.php
+++ b/seleccion_tableros.php
@@ -15,7 +15,7 @@ if (!isValidSharedUrl($sharedParam)) {
     $sharedParam = '';
 }
 $encodedShared = $sharedParam !== '' ? rawurlencode($sharedParam) : '';
-$skipUrl = 'panel.php' . ($encodedShared ? '?shared=' . $encodedShared : '');
+$skipUrl = $encodedShared ? 'agregar_favolink.php?shared=' . $encodedShared : 'panel.php';
 $user_id = $_SESSION['user_id'];
 
 $predefinedBoards = [


### PR DESCRIPTION
## Summary
- add `agregar_favolink.php` to handle favolink creation, metadata fetching and shared URL prefills
- replace the header modal with a link to the new page, update styles/JS to match the standalone layout and clear the `shared` query string
- route login, OAuth, onboarding and the Android receiver to the new view and refresh the technical manual accordingly

## Testing
- php -l agregar_favolink.php
- php -l header.php
- php -l login.php
- php -l oauth2callback.php
- php -l panel.php
- php -l seleccion_tableros.php
- node --check assets/main.js
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d0176da560832c93749b6d69b3dd1d