### PR TITLE
Remove tagline from add favolink page

### DIFF
--- a/agregar_favolink.php
+++ b/agregar_favolink.php
@@ -169,7 +169,6 @@ include 'header.php';
 <div class="favolink-page">
     <div class="favolink-card">
         <div class="app-logo"><img src="/img/logo_linkaloo_blue.png" alt="Linkaloo logo"></div>
-        <p class="favolink-tagline">Yours favolinks with superpowers</p>
         <h2 class="modal-title">Añadir tu favolink</h2>
         <div class="control-forms">
             <div class="form-section">


### PR DESCRIPTION
## Summary
- remove the "Yours favolinks with superpowers" tagline from the add favolink page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03603bcbc832ca193045341f503d2