### PR TITLE
Reduce mobile add button margin to align menu toggle

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -53,6 +53,7 @@ textarea {
 
 .open-modal,
 .add-link-btn{background:#1DA1F2;color:#fff;border:none;width:50px;height:50px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:36px;margin:0 5px;flex-shrink:0;padding:0;text-decoration:none;}
+.top-menu nav .add-link-btn.add-mobile{margin-right:0;}
 .open-modal svg,
 .add-link-btn svg{width:24px;height:24px;}
 .add-link-btn{border-radius:50%;}


### PR DESCRIPTION
## Summary
- remove the right margin from the mobile add-link button so the hamburger icon aligns with the header content edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d03da2ab58832c9ef3052e6774d8f5