### PR TITLE
Remove width constraint from mobile top menu links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -44,7 +44,7 @@ textarea {
     /* Restore default hamburger bar size on mobile */
     .menu-toggle span {width:25px;height:3px;margin:4px 0;}
     .top-menu li {padding:10px 25px;justify-content:flex-start;width:100%;}
-    .top-menu nav a {margin:0;font-size:20px;display:flex;align-items:center;justify-content:flex-start;width:100%;}
+    .top-menu nav a {margin:0;font-size:20px;display:flex;align-items:center;justify-content:flex-start;}
     .top-menu nav a svg,
     .top-menu nav a img {margin-right:8px;}
     .top-menu .logo {margin-left:-15px;}


### PR DESCRIPTION
## Summary
- remove the explicit 100% width assigned to `.top-menu nav a` in the mobile media query
- keep other responsive styling intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d057b1ea9c832ca9901d5eef95f85c