### PR TITLE
Adjust favolink page min-height

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -70,7 +70,7 @@ textarea {
 .modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:24px;cursor:pointer;}
 .add-modal-content h2.modal-title,
 .favolink-card .modal-title{text-align:center;margin:0 0 20px;color:#1DA1F2;}
-.favolink-page{min-height:calc(100vh - 80px);display:flex;align-items:center;justify-content:center;padding:40px 20px;background:#f5f8fa;}
+.favolink-page{min-height:calc(100vh - 120px);display:flex;align-items:center;justify-content:center;padding:40px 20px;background:#f5f8fa;}
 .favolink-card{background:#fff;color:#000;border-radius:20px;max-width:480px;width:100%;padding:35px 30px;box-shadow:0 10px 25px rgba(0,0,0,0.1);}
 .favolink-tagline{text-align:center;margin:0 0 10px;color:#1DA1F2;font-weight:700;}
 .favolink-card .control-forms{margin-top:10px;}


### PR DESCRIPTION
## Summary
- update the `.favolink-page` min-height calculation to use 120px instead of 80px

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05a35f67c832cb01f7829f5409c7f