### PR TITLE
Amplia documentación técnica y de uso

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,46 @@
 # Documentación de linkaloo
 
-Este directorio reúne los documentos principales del proyecto:
+Este directorio reúne la información necesaria para comprender, desplegar y operar la aplicación.
+Cada documento se centra en una perspectiva distinta: desde la visión técnica completa hasta las
+instrucciones para usuarios finales y la referencia de los endpoints disponibles.
 
-- `manual_tecnico.md`: panorama completo de la arquitectura, componentes, integraciones y prácticas recomendadas.
-- `estructura.md`: visión general de la arquitectura y de la base de datos.
-- `instalacion.md`: guía para preparar un entorno local de desarrollo.
-- `uso.md`: instrucciones paso a paso para utilizar la aplicación.
-- `endpoints.md`: referencia de los scripts PHP que actúan como API.
+## Cómo navegar por la documentación
+
+1. **¿Vas a preparar un entorno local?** Empieza por la [guía de instalación](instalacion.md) y, una vez
+   configurado todo, repasa la [guía de uso](uso.md) para validar que el flujo funciona.
+2. **¿Necesitas entender la arquitectura o planificas realizar cambios?** Lee el
+   [manual técnico](manual_tecnico.md), que detalla la organización del código, el modelo de datos y los
+   procesos principales.
+3. **¿Buscas un mapa rápido del repositorio o de la base de datos?** Consulta
+   [estructura.md](estructura.md) para conocer cómo se agrupan los archivos y tablas.
+4. **¿Vas a integrar el front-end con llamadas asíncronas?** Revisa la referencia de
+   [endpoints.md](endpoints.md) para conocer parámetros, respuestas y requisitos de autenticación.
+
+## Tabla de contenidos
+
+| Documento | Descripción |
+| --- | --- |
+| [manual_tecnico.md](manual_tecnico.md) | Panorama completo de arquitectura, flujos de negocio, servicios externos y prácticas recomendadas. |
+| [estructura.md](estructura.md) | Resumen de directorios, archivos clave y esquema de la base de datos. |
+| [instalacion.md](instalacion.md) | Pasos detallados para preparar un entorno local de desarrollo o pruebas. |
+| [uso.md](uso.md) | Guía paso a paso para operar la aplicación desde la interfaz web. |
+| [endpoints.md](endpoints.md) | Referencia de los scripts PHP que exponen respuestas JSON o sirven contenido público. |
+
+## Flujo general del proyecto
+
+1. Una persona se registra o inicia sesión (`register.php`, `login.php`) y el sistema emite un token de
+   sesión persistente gestionado por `session.php`.
+2. Desde el panel (`panel.php`) crea tableros (`tableros.php`, `tablero.php`) y guarda enlaces en
+   `agregar_favolink.php`. El front-end (`assets/main.js`) controla filtros, búsqueda y compartición.
+3. Las acciones de mantenimiento (mover, eliminar o cargar enlaces de forma incremental) se realizan
+   mediante los endpoints JSON `move_link.php`, `delete_link.php` y `load_links.php`.
+4. Opcionalmente se generan tableros públicos (`tablero_publico.php`) y se pueden compartir enlaces
+   individuales o completos usando la Web Share API o AddToAny.
 
 ## Comprobaciones rápidas
 
-Desde la raíz del repositorio puedes ejecutar las siguientes órdenes para verificar la instalación y el estilo del código:
+Desde la raíz del repositorio puedes ejecutar las siguientes órdenes para verificar la instalación y el
+estilo del código antes de publicar cambios:
 
 ```bash
 php -l config.php panel.php move_link.php load_links.php
@@ -18,4 +48,6 @@ node --check assets/main.js
 npm run lint:css
 ```
 
-Estas comprobaciones deben finalizar sin errores antes de contribuir cambios.
+Todas deben finalizar sin errores. El comando de PHP valida la sintaxis de los scripts críticos, `node
+--check` confirma que el JavaScript del front-end es válido y `npm run lint:css` aplica la configuración de
+Stylelint sobre `assets/style.css`.

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,35 +1,75 @@
 # Endpoints de la API
 
-Este documento describe los scripts PHP que actúan como puntos de entrada para las operaciones asíncronas del cliente.
-Todos requieren que el usuario tenga una sesión activa; de lo contrario devuelven un código 401 o `success: false`.
+Los siguientes scripts PHP exponen respuestas JSON o sirven contenido público que puede consumirse desde
+otros clientes. Todos ellos residen en la raíz del proyecto.
+
+## Reglas generales
+
+- Los endpoints JSON (`load_links.php`, `move_link.php`, `delete_link.php`) **requieren una sesión iniciada**. Si
+  no existe, devuelven `401` o `{ "success": false }`.
+- El cuerpo de las peticiones `POST` debe codificarse como `application/x-www-form-urlencoded`.
+- Las respuestas JSON se envían con `Content-Type: application/json; charset=utf-8` y utilizan UTF-8.
+- El tamaño de lote por defecto en `load_links.php` es de 18 elementos.
 
 ## `load_links.php`
 
-Obtiene un lote de enlaces del usuario.
+Recupera enlaces del usuario autenticado en bloques paginados.
 
 - **Método:** `GET`
 - **Parámetros:**
-  - `offset` (entero, opcional): número de enlaces ya cargados. Por defecto `0`.
-  - `cat` (entero o `"all"`, opcional): identificador del tablero. Si se omite o vale `all`, devuelve enlaces de todos los tableros.
+  - `offset` (`int`, opcional) – Número de enlaces ya cargados. Por defecto `0`.
+  - `cat` (`int` o `all`, opcional) – Identificador del tablero. Si es `all` (valor por defecto) devuelve enlaces de todos los tableros.
 - **Respuesta:** matriz JSON con objetos que incluyen `id`, `categoria_id`, `url`, `titulo`, `descripcion`, `imagen` y `favicon`.
+- **Ejemplo de respuesta:**
+  ```json
+  [
+    {
+      "id": 42,
+      "categoria_id": 3,
+      "url": "https://ejemplo.com/articulo",
+      "titulo": "Artículo destacado",
+      "descripcion": "Resumen corto…",
+      "imagen": "/fichas/3/42.png",
+      "favicon": "/local_favicons/ejemplo.com.png"
+    }
+  ]
+  ```
+
+Aunque el panel actual carga todos los enlaces directamente en PHP, este endpoint puede reutilizarse para
+implementar scroll infinito o integraciones externas.
 
 ## `move_link.php`
 
-Mueve un enlace a otro tablero.
+Actualiza el tablero al que pertenece un enlace.
 
 - **Método:** `POST`
 - **Parámetros:**
-  - `id` (entero, obligatorio): identificador del enlace.
-  - `categoria_id` (entero, obligatorio): identificador del tablero destino.
-- **Respuesta:** objeto JSON `{ "success": true }` si la operación se realiza correctamente, en caso contrario `{ "success": false }`.
+  - `id` (`int`, obligatorio) – Identificador del enlace a mover.
+  - `categoria_id` (`int`, obligatorio) – Identificador del tablero destino.
+- **Respuesta:**
+  - `{ "success": true }` cuando el enlace pertenece al usuario y se actualiza correctamente.
+  - `{ "success": false }` en cualquier otro caso (parámetros incorrectos, enlace inexistente, sesión caducada…).
+
+La operación actualiza también la columna `modificado_en` tanto del tablero origen como del destino.
 
 ## `delete_link.php`
 
-Elimina un enlace existente.
+Elimina un enlace del usuario autenticado.
 
 - **Método:** `POST`
 - **Parámetros:**
-  - `id` (entero, obligatorio): identificador del enlace a borrar.
-- **Respuesta:** objeto JSON con `success: true` si se borra el enlace; en caso contrario `success: false`.
+  - `id` (`int`, obligatorio) – Identificador del enlace.
+- **Respuesta:**
+  - `{ "success": true }` si el enlace se elimina y, en su caso, se actualiza la marca `modificado_en` del tablero asociado.
+  - `{ "success": false }` si la operación no se realiza.
 
-Estos endpoints actualizan la marca de modificación del tablero afectado para mantener la información sincronizada.
+## `tablero_publico.php`
+
+Expone la versión pública de un tablero previamente marcado como compartido.
+
+- **Método:** `GET`
+- **Parámetros:** `token` (`string`, obligatorio) – Valor almacenado en `categorias.share_token`.
+- **Respuesta:** HTML con las fichas del tablero en modo lectura. Si el token no existe o está vacío, devuelve un
+  mensaje `Tablero no disponible` con código de estado `404`.
+
+Este endpoint no requiere autenticación y se usa para compartir tableros completos fuera de la aplicación.

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -1,38 +1,58 @@
 # Estructura y arquitectura del proyecto
 
-Este documento ofrece una visión general de la aplicación **linkaloo** y de cómo está organizada.
+Este documento ofrece una panorámica rápida de cómo se organiza el repositorio y dónde se encuentran los
+componentes principales del backend, front-end y documentación.
 
-## Estructura de directorios
+## Raíz del repositorio
 
-- `index.php`: punto de entrada público con el formulario de acceso.
-- `login.php`, `register.php`, `logout.php`: gestión de autenticación.
-- `panel.php`: panel principal que muestra los tableros y enlaces del usuario.
-- `tablero.php`, `tableros.php`: creación y administración de tableros.
-- `assets/main.js`: código JavaScript que maneja la carga de enlaces, filtros y acciones en las tarjetas.
-- `assets/style.css`: hoja de estilos principal.
-- `load_links.php`, `move_link.php`, `editar_link.php`, `delete_link.php`: endpoints AJAX para operar sobre los enlaces.
-- `config.php`: configuración de la base de datos y credenciales opcionales de OAuth.
-- `img/`: logotipos y favicons.
+| Elemento | Descripción |
+| --- | --- |
+| `index.php` | Punto de entrada que redirige al panel o al login según exista una sesión activa. |
+| `login.php`, `register.php` | Formularios de autenticación con reCAPTCHA y soporte del parámetro `shared`. |
+| `panel.php` | Vista principal que lista tableros y enlaces del usuario autenticado. |
+| `agregar_favolink.php` | Formulario para crear enlaces nuevos, con scraping de metadatos e inserción automática de tableros. |
+| `tableros.php`, `tablero.php`, `tablero_publico.php` | Administración de tableros privados y vista pública asociada a `share_token`. |
+| `editar_link.php`, `move_link.php`, `delete_link.php`, `load_links.php` | Edición puntual y endpoints JSON para mover, borrar o paginar enlaces. |
+| `cpanel.php`, `cambiar_password.php` | Gestión de la cuenta y de la contraseña. |
+| `recuperar_password.php`, `restablecer_password.php` | Flujo de recuperación de contraseña mediante tokens temporales. |
+| `oauth.php`, `oauth2callback.php`, `logout.php` | Inicio de sesión con Google, callback y cierre de sesión. |
+| `config.php`, `session.php`, `device.php` | Configuración de base de datos y OAuth, gestión de sesiones y detección de dispositivo. |
+| `favicon_utils.php`, `image_utils.php` | Utilidades para descargar favicons y normalizar imágenes. |
+| `database.sql` | Script SQL con la definición inicial de tablas e índices. |
+| `ShareReceiverActivity.kt`, `AndroidManifest.xml` | Cliente Android que permite compartir enlaces hacia la aplicación web. |
 
-## Esquema de la base de datos
+## Directorios relevantes
 
-La base de datos se define en `database.sql` y utiliza codificación `utf8mb4`.
+| Carpeta | Contenido |
+| --- | --- |
+| `assets/` | `main.js` (comportamiento del panel y vistas) y `style.css` (estilos principales). |
+| `docs/` | Guías de instalación, uso, referencia de endpoints y este mismo documento. |
+| `fichas/` | Imágenes descargadas automáticamente desde los enlaces guardados. |
+| `img/` | Recursos estáticos (logos, iconos) utilizados en la interfaz. |
+| `local_favicons/` | Favicons en caché generados por `favicon_utils.php`. |
+| `node_modules/` | Dependencias de desarrollo de Node para Stylelint. |
 
-- **usuarios**: almacena las credenciales básicas (`id`, `nombre`, `email`, `pass_hash`).
-- **categorias**: representa los tableros personales del usuario. Incluye nombre, color, imagen, nota y token de compartición.
-- **links**: registros individuales de cada enlace guardado. Contiene URL, título, descripción, favicon y referencias al usuario y a la categoría.
+## Recursos legales y páginas estáticas
 
-## Flujo principal
+Los archivos `cookies.php`, `politica_cookies.php`, `politica_privacidad.php`, `condiciones_servicio.php` y
+`quienes_somos.php` contienen textos legales listos para personalizar. Están enlazados desde el menú de ajustes
+de `header.php` y se sirven como páginas PHP simples sin lógica adicional.
 
-1. Un usuario se registra o inicia sesión.
-2. Desde el panel puede crear tableros y agregar enlaces mediante el botón “+”.
-3. Cada tarjeta de enlace permite mover, buscar, compartir o eliminar el recurso.
-4. El desplazamiento infinito carga enlaces adicionales a partir de la ficha 18 para optimizar el rendimiento.
+## Modelo de datos
 
-## Configuración
+La base de datos se crea ejecutando `database.sql` y utiliza la codificación `utf8mb4`. Las tablas principales
+son:
 
-- Crea la base de datos ejecutando `database.sql`.
-- Define las credenciales en `config.php`.
-- Para el login con Google, configura las variables `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`.
-- Registra `http://localhost:8000/oauth2callback.php` (o `https://linkaloo.com/oauth2callback.php`) como URI de redirección autorizada; corresponde al endpoint de backend que procesa el callback OAuth.
+- **usuarios:** credenciales y datos básicos de cada persona registrada.
+- **categorias:** tableros asociados a un usuario, con campos para notas, token público e imagen de portada.
+- **links:** enlaces individuales con URL original y canónica, título, descripción, imagen, notas y `hash_url`.
+- **password_resets:** tokens temporales para restablecer contraseñas.
+- **usuario_tokens:** tokens persistentes empleados para la funcionalidad "remember me".
 
+Cada tabla incluye marcas de auditoría (`creado_en`, `modificado_en`) para facilitar informes o limpieza de datos.
+
+## Flujo de archivos estáticos
+
+`header.php` incorpora `assets/style.css` y `assets/main.js` con query strings basados en `filemtime` para forzar la
+actualización en los navegadores. Los favicons se almacenan en `local_favicons/` y las imágenes completas en
+`fichas/`, reutilizándose en paneles y tableros públicos para optimizar tiempos de carga.

--- a/docs/instalacion.md
+++ b/docs/instalacion.md
@@ -1,26 +1,58 @@
 # Guía de instalación
 
-Este documento describe el proceso para preparar un entorno local de desarrollo para **linkaloo**.
+Esta guía explica cómo preparar un entorno local de desarrollo o pruebas para **linkaloo**.
 
 ## Requisitos
 
-- PHP 8
-- MySQL 8
-- Node.js 18
-- npm
+- **PHP 8.1 o superior** con las extensiones PDO (MySQL), cURL, mbstring, DOM, JSON y GD habilitadas.
+- **MySQL 8** (o MariaDB compatible) para persistir la información.
+- **Node.js 18** y **npm** para ejecutar Stylelint sobre los estilos.
+- Acceso a Internet para resolver dependencias y, opcionalmente, para que cURL obtenga metadatos y favicons.
 
-## Pasos
+## Preparación del proyecto
 
-1. Clona el repositorio en tu máquina.
-2. Crea una base de datos MySQL y ejecuta `database.sql` para generar las tablas.
-3. Ajusta las credenciales de acceso en `config.php`.
-4. Instala las dependencias de desarrollo con `npm install`.
-5. Inicia un servidor PHP en la raíz del proyecto: `php -S localhost:8000`.
-6. Abre `http://localhost:8000` en tu navegador.
+1. Clona el repositorio en tu máquina local.
+2. Entra en el directorio raíz (`cd linkaloo.com`).
+3. Instala las dependencias de desarrollo ejecutando `npm install`.
+4. Comprueba que `node_modules/` contiene Stylelint y su configuración (`stylelint.config.js`).
 
-## Verificación
+## Configuración de la base de datos
 
-Desde la raíz del proyecto puedes ejecutar las comprobaciones básicas:
+1. Crea una base de datos vacía en MySQL (por ejemplo, `linkaloo_dev`).
+2. Ejecuta el script `database.sql` sobre esa base para crear tablas e índices iniciales. Puedes usar `mysql`:
+   ```bash
+   mysql -u <usuario> -p linkaloo_dev < database.sql
+   ```
+3. Edita `config.php` para apuntar a tu servidor local. Ajusta `host`, `dbname`, `username` y `password`. En
+   entornos de producción se recomienda extraer estas credenciales a variables de entorno o a un archivo no versionado.
+
+## Claves externas y variables de entorno
+
+- **Google OAuth:** define `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_REDIRECT_URI` en el entorno si no
+  quieres usar los valores de respaldo incluidos en `config.php`.
+- **reCAPTCHA v3:** establece `RECAPTCHA_SITE_KEY` y `RECAPTCHA_SECRET_KEY` con tus claves. Si no lo haces, se
+  utilizarán las llaves de ejemplo del archivo de configuración.
+- Exporta las variables antes de iniciar el servidor, por ejemplo:
+  ```bash
+  export GOOGLE_CLIENT_ID="tu-client-id"
+  export GOOGLE_CLIENT_SECRET="tu-client-secret"
+  export RECAPTCHA_SITE_KEY="tu-site-key"
+  export RECAPTCHA_SECRET_KEY="tu-secret-key"
+  ```
+
+## Servidor local
+
+1. Arranca un servidor PHP embebido desde la raíz del proyecto:
+   ```bash
+   php -S localhost:8000
+   ```
+2. Abre `http://localhost:8000` en tu navegador y crea una cuenta de prueba.
+3. Si vas a probar el flujo de recuperación de contraseña, configura previamente el envío de correo en tu
+   entorno (`sendmail`, `mailhog`, etc.) o adapta `recuperar_password.php` para utilizar un proveedor SMTP.
+
+## Comprobaciones recomendadas
+
+Antes de subir cambios o desplegar, ejecuta las verificaciones básicas:
 
 ```bash
 php -l config.php panel.php move_link.php load_links.php
@@ -28,4 +60,5 @@ node --check assets/main.js
 npm run lint:css
 ```
 
-Si todas las órdenes finalizan sin errores, la instalación se ha realizado correctamente.
+Todas deben finalizar sin errores. Si modificas la base de datos, vuelve a ejecutar `database.sql` en un entorno
+limpio o documenta las migraciones necesarias.

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -1,28 +1,70 @@
 # Guía de uso
 
-Este documento describe el flujo básico para interactuar con **linkaloo** desde la interfaz web.
+Esta guía describe el flujo básico para trabajar con **linkaloo** desde la interfaz web. Todas las vistas
+comparten la cabecera (`header.php`), desde la que puedes acceder al panel, a tus tableros, a la cuenta y a
+las páginas legales.
 
 ## Registro e inicio de sesión
 
-1. Abre la página `index.php`.
-2. Regístrate con un correo y contraseña o accede con tus credenciales existentes.
-3. Opcionalmente puedes autenticarte mediante Google desde `login.php`.
+1. Abre `http://localhost:8000` (o la URL desplegada) para acceder al formulario de inicio (`login.php`).
+2. Inicia sesión con tu correo y contraseña o usa el botón **Google** para autenticarte mediante OAuth.
+3. Si aún no tienes cuenta, sigue el enlace **Registrarse** y completa el formulario (`register.php`). Se
+   validará el reCAPTCHA v3 antes de crear el usuario. Al finalizar se abrirá `seleccion_tableros.php` para que
+   elijas tableros iniciales.
+4. Al iniciar sesión se genera una cookie "remember me" válida durante 365 días, de modo que la siguiente vez
+   accederás directamente al panel.
 
-## Gestión de tableros
+## Gestionar tableros
 
-1. En el panel principal crea tableros para organizar tus enlaces.
-2. Usa el menú de cada tablero para renombrarlo, añadir notas o eliminarlo.
+- En `tableros.php` verás todos tus tableros con el recuento de enlaces y accesos directos para compartirlos o
+  editarlos.
+- Pulsa **Crear** para añadir un nuevo tablero. También puedes crear uno desde `agregar_favolink.php` escribiendo
+  un nombre en el campo "o crea un nuevo".
+- Abre un tablero concreto desde `tablero.php` para editar su nombre, añadir una nota, activar la compartición
+  pública o eliminarlo por completo. El botón **Actualizar imágenes** vuelve a descargar las portadas de los
+  enlaces guardados.
 
-## Guardar y organizar enlaces
+## Añadir y organizar enlaces
 
-1. Pulsa el botón “+” para agregar un nuevo enlace.
-2. Completa el título y la descripción opcional; el favicon se obtiene automáticamente.
-3. Cada tarjeta permite mover el enlace a otro tablero, buscarlo, compartirlo o eliminarlo.
+1. Usa el botón **+** del menú o el acceso directo en `panel.php` para abrir `agregar_favolink.php`.
+2. Pega la URL en "Pega aquí el link". El sistema intentará recuperar título, descripción e imagen mediante
+   scraping y se encargará de generar un favicon si no hay imagen.
+3. Selecciona un tablero existente o crea uno nuevo. Al guardar, se comprueba automáticamente si la URL ya
+   existe para el usuario (a través de `hash_url`).
+4. Las tarjetas aparecerán en el panel con botones para editar, compartir, mover o eliminar cada enlace.
+5. Cambia un enlace de tablero con el desplegable; la acción es inmediata y se sincroniza con el servidor sin
+   recargar la página.
 
-## Tableros públicos
+## Búsqueda y navegación
 
-Cada tablero genera un enlace de compartición que muestra sus fichas en `tablero_publico.php`. Comparte ese enlace para dar acceso de solo lectura.
+- El carrusel superior del panel permite filtrar por tablero. El desplazamiento lateral se recuerda durante la
+  sesión.
+- Pulsa el icono de búsqueda para mostrar el campo de filtro. Escribe palabras clave y las tarjetas se filtrarán
+  en tiempo real.
+- Las tarjetas se animan al entrar en pantalla y muestran descripciones truncadas según el ancho del dispositivo.
 
-## Compartir
+## Tableros públicos y compartición
 
-El icono de compartir utiliza la Web Share API cuando está disponible; si no, copia la URL al portapapeles.
+- Activa la casilla **Compartir tablero públicamente** en `tablero.php` para generar un `share_token`. Obtendrás
+  un enlace directo a `tablero_publico.php?token=...` con las fichas en modo lectura.
+- El icono de compartir utiliza la Web Share API cuando está disponible. Si no, abre una ventana de AddToAny con
+  la URL y el título del tablero.
+- En cada tarjeta también encontrarás un botón de compartir que aplica el mismo comportamiento para enlaces
+  individuales.
+
+## Cuenta y seguridad
+
+- Desde `cpanel.php` puedes actualizar tu nombre y correo. Los cambios se aplican inmediatamente.
+- En `cambiar_password.php` introduce tu contraseña actual y la nueva para actualizar el hash almacenado.
+- Usa `logout.php` para cerrar sesión y revocar la cookie persistente del navegador.
+
+## Recuperar acceso
+
+Si olvidaste la contraseña, visita `recuperar_password.php` y escribe tu correo. Se generará un enlace con
+caducidad de una hora; al abrirlo (`restablecer_password.php`) podrás introducir una contraseña nueva.
+
+## Compartir desde Android
+
+El repositorio incluye `ShareReceiverActivity.kt`, que registra un intent filter para recibir enlaces desde
+otras aplicaciones Android. Al compartir hacia Linkaloo se abrirá `agregar_favolink.php` con el campo URL
+rellenado automáticamente gracias al parámetro `shared`.


### PR DESCRIPTION
## Summary
- reorganize el índice de la documentación para facilitar el acceso a guías y referencias
- ampliar el manual técnico con detalles sobre arquitectura, sesiones, base de datos e integraciones
- actualizar guías de estructura, instalación, uso y endpoints con instrucciones completas y ejemplos

## Testing
- php -l config.php panel.php move_link.php load_links.php
- node --check assets/main.js
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d0fa3e23d4832c856ae8a21049d273