### PR TITLE
Ensure shared links open agregar_favolink with prefilled URL

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,15 +13,16 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
+                <data android:mimeType="text/uri-list" />
             </intent-filter>
 
             <!-- Abrir enlaces directamente -->
-            <intent-filter android:autoVerify="true">
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                 <data android:scheme="https" android:host="linkaloo.com" />
-                 <data android:scheme="http" android:host="linkaloo.com" />
+                 <data android:scheme="https" />
+                 <data android:scheme="http" />
              </intent-filter>
          </activity>
      </application>


### PR DESCRIPTION
## Summary
- widen the share intent filter to accept text and URI lists and catch generic http/https VIEW intents
- update ShareReceiverActivity to extract the shared URL, forward it to https://linkaloo.com/agregar_favolink.php, and avoid redirect loops by preferring external browsers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0ff1e3e38832cbd26c44d18024c5e