### PR TITLE
Expand asset links for deep link handling

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,12 +1,36 @@
 [
   {
-    "relation": ["delegate_permission/common.handle_all_urls"],
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "com.android.linkaloo",
       "sha256_cert_fingerprints": [
         "69:32:D5:82:6E:9B:D1:79:96:48:5D:90:7F:5C:75:4F:42:8F:BD:28:FE:2F:15:AC:FE:25:6C:56:C6:1D:C8:16"
       ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "web",
+      "site": "https://linkaloo.com/"
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "web",
+      "site": "https://www.linkaloo.com/"
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "web",
+      "site": "https://app.linkaloo.com/"
     }
   }
 ]


### PR DESCRIPTION
## Summary
- extend the digital asset links statement so the Android client can both handle incoming URLs and reuse stored credentials
- declare additional web associations for the canonical, www, and app hostnames to cover deep links that target each variant

## Testing
- not run (configuration file change)


------
https://chatgpt.com/codex/tasks/task_e_68d14ff2413c832c9e9436dd76c23961