### PR TITLE
Ensure deep links target agregar_favolink

### DIFF
--- a/ShareReceiverActivity.kt
+++ b/ShareReceiverActivity.kt
@@ -13,6 +13,7 @@ class ShareReceiverActivity : AppCompatActivity() {
 
     private companion object {
         private const val EXTRA_ALREADY_REDIRECTED = "com.android.linkaloo.EXTRA_ALREADY_REDIRECTED"
+        private const val LINKALOO_DEEP_LINK_TARGET = "//linkaloo.com/agregar_favolink.php"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -63,7 +64,7 @@ class ShareReceiverActivity : AppCompatActivity() {
         }
 
         Log.d("ShareReceiver", "Forwarding shared link: $sharedUrl")
-        val targetUri = Uri.parse("https://linkaloo.com/agregar_favolink.php").buildUpon()
+        val targetUri = Uri.parse("https:$LINKALOO_DEEP_LINK_TARGET").buildUpon()
             .appendQueryParameter("shared", sharedUrl)
             .build()
         openInBrowser(targetUri, alreadyRedirected = false)


### PR DESCRIPTION
## Summary
- define a constant for the Linkaloo deep link target pointing to `//linkaloo.com/agregar_favolink.php`
- build the redirect URI for forwarded shares from that constant so incoming deep links land on the correct page

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d153ea517c832cb10d267a2cead3d7