### PR TITLE
Handle custom linkaloo deep links

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,13 +17,23 @@
             </intent-filter>
 
             <!-- Abrir enlaces directamente -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="linkaloo.com" />
+                <data android:scheme="https" android:host="www.linkaloo.com" />
+                <data android:scheme="https" android:host="app.linkaloo.com" />
+                <data android:scheme="http" android:host="linkaloo.com" />
+                <data android:scheme="http" android:host="www.linkaloo.com" />
+                <data android:scheme="http" android:host="app.linkaloo.com" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                 <data android:scheme="https" />
-                 <data android:scheme="http" />
-             </intent-filter>
+                <data android:scheme="linkaloo" android:host="linkaloo.com" />
+            </intent-filter>
          </activity>
      </application>
   </manifest>


### PR DESCRIPTION
## Summary
- register the `linkaloo://` custom scheme and verified HTTPS hosts in the manifest so the app can answer deep links
- update the share receiver to normalize incoming `linkaloo://` URIs, build matching deep links when forwarding shared URLs and fall back to the web form when needed

## Testing
- not run (android toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d15b26b0bc832ca74114beb4e66142