### PR TITLE
Fortalecer validaciones en los flujos de login

### DIFF
--- a/login.php
+++ b/login.php
@@ -15,41 +15,89 @@ if (!isValidSharedUrl($sharedParam)) {
 $encodedShared = $sharedParam !== '' ? rawurlencode($sharedParam) : '';
 $registerUrl   = 'register.php' . ($encodedShared ? '?shared=' . $encodedShared : '');
 $googleOauthUrl = 'oauth.php?provider=google' . ($encodedShared ? '&shared=' . $encodedShared : '');
+$recaptchaConfigured = !empty($recaptchaSiteKey) && !empty($recaptchaSecretKey);
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
+    $email = trim($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';
     $captcha = $_POST['g-recaptcha-response'] ?? '';
-    if ($email && $password) {
-        $captchaValid = false;
-        if ($captcha && !empty($recaptchaSecretKey)) {
-            $response = file_get_contents("https://www.google.com/recaptcha/api/siteverify?secret={$recaptchaSecretKey}&response={$captcha}");
-            $data = json_decode($response, true);
-            $captchaValid = ($data['success'] ?? false)
-                && ($data['score'] ?? 0) >= 0.5
-                && ($data['action'] ?? '') === 'login';
-        }
-        if ($captchaValid) {
-            $stmt = $pdo->prepare('SELECT id, nombre, pass_hash FROM usuarios WHERE email = ?');
-            $stmt->execute([$email]);
-            $user = $stmt->fetch();
-            if ($user && password_verify($password, $user['pass_hash'])) {
-                session_regenerate_id(true);
-                $_SESSION['user_id'] = (int) $user['id'];
-                $_SESSION['user_name'] = $user['nombre'];
-                linkalooIssueRememberMeToken($pdo, (int) $user['id']);
-                $redirect = 'panel.php';
-                if ($sharedParam !== '') {
-                    $redirect = 'agregar_favolink.php?shared=' . rawurlencode($sharedParam);
-                }
-                header('Location: ' . $redirect);
-                exit;
-            } else {
-                $error = 'Usuario o contraseña incorrectos';
-            }
+    if ($email !== '' && $password !== '') {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $error = 'Introduce un email válido';
         } else {
-            $error = 'Verificación humana fallida';
+            $captchaValid = true;
+            if ($recaptchaConfigured) {
+                $captchaValid = false;
+                $captchaError = 'Verificación humana fallida';
+                if ($captcha !== '') {
+                    $payload = [
+                        'secret'   => $recaptchaSecretKey,
+                        'response' => $captcha,
+                    ];
+                    if (!empty($_SERVER['REMOTE_ADDR'])) {
+                        $payload['remoteip'] = $_SERVER['REMOTE_ADDR'];
+                    }
+                    $ch = curl_init('https://www.google.com/recaptcha/api/siteverify');
+                    if ($ch !== false) {
+                        curl_setopt_array($ch, [
+                            CURLOPT_POST            => true,
+                            CURLOPT_RETURNTRANSFER  => true,
+                            CURLOPT_TIMEOUT         => 5,
+                            CURLOPT_CONNECTTIMEOUT  => 3,
+                            CURLOPT_POSTFIELDS      => http_build_query($payload),
+                        ]);
+                        $verifyResponse = curl_exec($ch);
+                        if ($verifyResponse === false) {
+                            error_log('Error verificando reCAPTCHA: ' . curl_error($ch));
+                            $captchaError = 'No se pudo verificar que eres una persona. Inténtalo de nuevo.';
+                        } else {
+                            $data = json_decode($verifyResponse, true);
+                            if (is_array($data)
+                                && ($data['success'] ?? false)
+                                && ($data['score'] ?? 0) >= 0.5
+                                && ($data['action'] ?? '') === 'login') {
+                                $captchaValid = true;
+                            } else {
+                                if (is_array($data) && isset($data['error-codes'])) {
+                                    error_log('Fallo en verificación reCAPTCHA: ' . implode(', ', (array) $data['error-codes']));
+                                } else {
+                                    error_log('Respuesta inesperada de reCAPTCHA: ' . $verifyResponse);
+                                }
+                            }
+                        }
+                        curl_close($ch);
+                    } else {
+                        error_log('No se pudo inicializar cURL para reCAPTCHA.');
+                        $captchaError = 'No se pudo verificar que eres una persona. Inténtalo de nuevo.';
+                    }
+                } else {
+                    $captchaError = 'No se recibió respuesta de reCAPTCHA. Inténtalo de nuevo.';
+                }
+                if (!$captchaValid) {
+                    $error = $captchaError;
+                }
+            }
+
+            if ($error === '') {
+                $stmt = $pdo->prepare('SELECT id, nombre, pass_hash FROM usuarios WHERE email = ?');
+                $stmt->execute([$email]);
+                $user = $stmt->fetch();
+                if ($user && password_verify($password, $user['pass_hash'])) {
+                    session_regenerate_id(true);
+                    $_SESSION['user_id'] = (int) $user['id'];
+                    $_SESSION['user_name'] = $user['nombre'];
+                    linkalooIssueRememberMeToken($pdo, (int) $user['id']);
+                    $redirect = 'panel.php';
+                    if ($sharedParam !== '') {
+                        $redirect = 'agregar_favolink.php?shared=' . rawurlencode($sharedParam);
+                    }
+                    header('Location: ' . $redirect);
+                    exit;
+                } else {
+                    $error = 'Usuario o contraseña incorrectos';
+                }
+            }
         }
     } else {
         $error = 'Introduce email y contraseña';
@@ -66,7 +114,7 @@ include 'header.php';
             <input type="email" name="email" placeholder="Email">
             <input type="password" name="password" placeholder="Contraseña">
             <input type="hidden" name="shared" value="<?= htmlspecialchars($sharedParam, ENT_QUOTES, 'UTF-8') ?>">
-            <?php if(!empty($recaptchaSiteKey)): ?>
+            <?php if($recaptchaConfigured): ?>
             <input type="hidden" name="g-recaptcha-response" id="g-recaptcha-response">
             <?php endif; ?>
             <button type="submit">Entrar</button>
@@ -80,7 +128,7 @@ include 'header.php';
     </div>
 </div>
 </div>
-<?php if(!empty($recaptchaSiteKey)): ?>
+<?php if($recaptchaConfigured): ?>
 <script src="https://www.google.com/recaptcha/api.js?render=<?= $recaptchaSiteKey ?>"></script>
 <script>
 document.getElementById('login-form').addEventListener('submit', function(e) {


### PR DESCRIPTION
## Summary
- endurecer la validación del formulario manual de login con comprobaciones de email y manejo robusto de reCAPTCHA
- ajustar la interfaz para solo cargar reCAPTCHA cuando la configuración está completa
- reforzar el callback de Google OAuth verificando el token de estado, validando el email y exigiendo cuentas verificadas

## Testing
- php -l login.php
- php -l oauth2callback.php

------
https://chatgpt.com/codex/tasks/task_e_68d18c2a34f4832cb7df103284c27ad1