### PR TITLE
Handle Google OAuth token fallback

### DIFF
--- a/oauth.php
+++ b/oauth.php
@@ -25,7 +25,7 @@ if ($provider === 'google') {
         'prompt' => 'select_account',
         'state' => $stateToken,
     ];
-    $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($queryParams);
+    $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
     header('Location: ' . $authUrl);
     exit;
 }


### PR DESCRIPTION
## Summary
- encode the Google authorization request using RFC 3986 query encoding
- add helpers to decode Google ID tokens and fall back to them when no access token is returned
- reuse the token endpoint response to populate profile data without failing on Firefox

## Testing
- php -l oauth.php
- php -l oauth2callback.php

------
https://chatgpt.com/codex/tasks/task_e_68d1a3c93c2c832c82d40943d2ddaf54