### PR TITLE
Rename offline illustration asset reference

### DIFF
--- a/.gitnomore
+++ b/.gitnomore
@@ -1,1 +1,1 @@
-img/Trabajando Desconectado_500.jpg
+img/Trabajando_Desconectado_500.jpg

--- a/offline.php
+++ b/offline.php
@@ -35,7 +35,7 @@
 </head>
 <body>
     <main class="offline-wrapper">
-        <img src="/img/Trabajando%20Desconectado_500.jpg" alt="Ilustración de linkaloo trabajando sin conexión">
+        <img src="/img/Trabajando_Desconectado_500.jpg" alt="Ilustración de linkaloo trabajando sin conexión">
         <p>No podemos conectar con linkaloo en este momento.<br>Revisa tu conexión a internet e inténtalo de nuevo.</p>
     </main>
 </body>


### PR DESCRIPTION
## Summary
- update the offline page to use the new image filename without spaces
- adjust the .gitnomore entry to document the renamed asset

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d29f060ca0832cae3da429738d9372