### PR TITLE
Add account deletion flow accessible from control panel

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -167,6 +167,14 @@ textarea {
 .login-form {display:flex;flex-direction:column;gap:10px;}
 .login-form input {padding:8px;}
 .login-form button {background:#1DA1F2;color:#fff;border:none;padding:10px;border-radius:4px;cursor:pointer;text-align:center;}
+.login-form input[type="checkbox"]{width:auto;padding:0;margin:0;}
+.login-form label.checkbox-label{display:flex;align-items:flex-start;gap:8px;font-size:14px;color:#555;text-align:left;line-height:1.4;}
+.login-form label.checkbox-label span{flex:1;}
+.warning-text{font-size:14px;color:#555;line-height:1.5;text-align:left;margin-bottom:10px;}
+.login-form button.danger{background:#dc3545;}
+.login-form button.danger:hover{background:#c82333;}
+.login-links .danger-link{color:#dc3545;}
+.login-links .danger-link:hover{color:#bd2130;}
 .login-links {display:flex;justify-content:space-between;margin-top:10px;}
 .login-links a {color:#1DA1F2;text-decoration:none;font-size:14px;}
 .social-block {text-align:center;}

--- a/cpanel.php
+++ b/cpanel.php
@@ -38,6 +38,7 @@ include 'header.php';
         </form>
         <div class="login-links">
             <a href="cambiar_password.php">Cambiar contraseña</a>
+            <a href="eliminar_cuenta.php" class="danger-link">Eliminar cuenta</a>
             <a href="logout.php">Salir</a>
         </div>
     </div>

--- a/eliminar_cuenta.php
+++ b/eliminar_cuenta.php
@@ -1,0 +1,102 @@
+<?php
+require 'config.php';
+require_once 'session.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$userId        = (int) $_SESSION['user_id'];
+$errorMessages = [];
+$errorHtml     = '';
+$success       = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $password = $_POST['password'] ?? '';
+    $confirmed = isset($_POST['confirm']) && $_POST['confirm'] === '1';
+
+    if ($password === '') {
+        $errorMessages[] = 'Introduce tu contraseña para confirmar.';
+    }
+
+    if (!$confirmed) {
+        $errorMessages[] = 'Marca la casilla para confirmar que deseas eliminar tu cuenta.';
+    }
+
+    if (empty($errorMessages)) {
+        $stmt = $pdo->prepare('SELECT pass_hash FROM usuarios WHERE id = ? LIMIT 1');
+        $stmt->execute([$userId]);
+        $user = $stmt->fetch();
+
+        if (!$user || !password_verify($password, $user['pass_hash'])) {
+            $errorMessages[] = 'La contraseña no es correcta.';
+        } else {
+            try {
+                $deleteStmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+                $deleteStmt->execute([$userId]);
+
+                linkalooClearRememberMeToken($pdo);
+
+                $_SESSION = [];
+                if (ini_get('session.use_cookies')) {
+                    $params = session_get_cookie_params();
+                    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+                } else {
+                    setcookie(session_name(), '', time() - 42000, '/');
+                }
+
+                if (session_status() === PHP_SESSION_ACTIVE) {
+                    session_destroy();
+                }
+
+                $success = true;
+            } catch (Throwable $exception) {
+                error_log('Error deleting account: ' . $exception->getMessage());
+                $errorMessages[] = 'No se pudo eliminar la cuenta. Inténtalo más tarde.';
+            }
+        }
+    }
+}
+
+if (!empty($errorMessages)) {
+    $safeMessages = array_map(static function ($message) {
+        return htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+    }, $errorMessages);
+    $errorHtml = implode('<br>', $safeMessages);
+}
+
+include 'header.php';
+?>
+<div class="login-wrapper">
+    <div class="login-block">
+        <?php if ($success): ?>
+            <h2>Cuenta eliminada</h2>
+            <p class="notice">Tu cuenta y todos tus datos se han eliminado correctamente.</p>
+            <div class="login-links">
+                <a href="index.php">Ir a la página principal</a>
+                <a href="register.php">Crear una nueva cuenta</a>
+            </div>
+        <?php else: ?>
+            <h2>Eliminar cuenta</h2>
+            <p class="warning-text">Eliminar tu cuenta es irreversible. Se borrarán tus tableros, enlaces y cualquier otro dato asociado.</p>
+            <?php if ($errorHtml !== ''): ?>
+                <p class="error"><?= $errorHtml ?></p>
+            <?php endif; ?>
+            <form method="post" class="login-form">
+                <input type="password" name="password" placeholder="Contraseña actual" required>
+                <label class="checkbox-label">
+                    <input type="checkbox" name="confirm" value="1" required>
+                    <span>Confirmo que deseo eliminar mi cuenta y entiendo que esta acción no se puede deshacer.</span>
+                </label>
+                <button type="submit" class="danger">Eliminar cuenta</button>
+            </form>
+            <div class="login-links">
+                <a href="cpanel.php">Cancelar y volver</a>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `eliminar_cuenta.php` so users can confirm account removal with their password and an explicit checkbox
- clear active sessions and remember-me tokens after deleting the user and show a confirmation view
- style destructive account actions and expose the flow from the control panel navigation

## Testing
- npm run lint:css
- php -l eliminar_cuenta.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d726f2c8832ca793a964364d723c