### PR TITLE
Add Firebase initialization script to pages

### DIFF
--- a/agregar_favolink.php
+++ b/agregar_favolink.php
@@ -193,5 +193,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/cambiar_password.php
+++ b/cambiar_password.php
@@ -45,5 +45,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/condiciones_servicio.php
+++ b/condiciones_servicio.php
@@ -13,5 +13,6 @@
 <p>Podemos modificar estas condiciones en cualquier momento. Las versiones actualizadas estarán disponibles en esta página.</p>
 <p>Para cualquier consulta puedes contactar con nosotros en <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/cookies.php
+++ b/cookies.php
@@ -3,5 +3,6 @@
 <p>linkaloo utiliza cookies propias y de terceros para recordar tus preferencias, medir el uso del sitio y mejorar nuestros servicios.</p>
 <p>Al continuar navegando aceptas su uso. Puedes obtener más información o gestionar tus preferencias en nuestra <a href="/politica_cookies.php">Política de cookies</a>.</p>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/cpanel.php
+++ b/cpanel.php
@@ -44,5 +44,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/editar_link.php
+++ b/editar_link.php
@@ -64,5 +64,6 @@ $favicon = $domain ? getLocalFavicon($domain) : '';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/eliminar_cuenta.php
+++ b/eliminar_cuenta.php
@@ -98,5 +98,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/firebase_scripts.php
+++ b/firebase_scripts.php
@@ -1,0 +1,23 @@
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAB8qBGmzwy15sqxyLevfGYU5GwAZtTAR8",
+    authDomain: "linkaloo-6ca2f.firebaseapp.com",
+    projectId: "linkaloo-6ca2f",
+    storageBucket: "linkaloo-6ca2f.firebasestorage.app",
+    messagingSenderId: "170566271159",
+    appId: "1:170566271159:web:d050991bb5d1b677410d32",
+    measurementId: "G-1KZQW4DWJP"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>

--- a/login.php
+++ b/login.php
@@ -142,5 +142,6 @@ document.getElementById('login-form').addEventListener('submit', function(e) {
 });
 </script>
 <?php endif; ?>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -88,5 +88,28 @@
             <p class="offline-footnote">Si el problema persiste, vuelve a intentarlo más tarde.</p>
         </section>
     </main>
+    <script type="module">
+      // Import the functions you need from the SDKs you need
+      import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
+      import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
+      // TODO: Add SDKs for Firebase products that you want to use
+      // https://firebase.google.com/docs/web/setup#available-libraries
+
+      // Your web app's Firebase configuration
+      // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+      const firebaseConfig = {
+        apiKey: "AIzaSyAB8qBGmzwy15sqxyLevfGYU5GwAZtTAR8",
+        authDomain: "linkaloo-6ca2f.firebaseapp.com",
+        projectId: "linkaloo-6ca2f",
+        storageBucket: "linkaloo-6ca2f.firebasestorage.app",
+        messagingSenderId: "170566271159",
+        appId: "1:170566271159:web:d050991bb5d1b677410d32",
+        measurementId: "G-1KZQW4DWJP"
+      };
+
+      // Initialize Firebase
+      const app = initializeApp(firebaseConfig);
+      const analytics = getAnalytics(app);
+    </script>
 </body>
 </html>

--- a/offline.php
+++ b/offline.php
@@ -38,5 +38,6 @@
         <img src="/img/Trabajando_Desconectado_500.jpg" alt="Ilustración de linkaloo trabajando sin conexión">
         <p>No podemos conectar con linkaloo en este momento.<br>Revisa tu conexión a internet e inténtalo de nuevo.</p>
     </main>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/panel.php
+++ b/panel.php
@@ -143,5 +143,6 @@ foreach ($links as $link):
 </div>
 
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/politica_cookies.php
+++ b/politica_cookies.php
@@ -16,5 +16,6 @@
 <p>Podemos actualizar esta política para reflejar cambios legislativos o en el servicio. Te recomendamos revisarla periódicamente.</p>
 <p>Si tienes dudas, escríbenos a <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/politica_privacidad.php
+++ b/politica_privacidad.php
@@ -21,5 +21,6 @@
 <h2>Cambios en la política</h2>
 <p>Podemos modificar esta política para adaptarla a novedades legislativas o de funcionamiento. Te avisaremos de los cambios significativos a través del servicio.</p>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/quienes_somos.php
+++ b/quienes_somos.php
@@ -5,5 +5,6 @@
 <p>El proyecto es desarrollado por un pequeño equipo independiente que valora la privacidad y la experiencia de usuario.</p>
 <p>Si quieres ponerte en contacto con nosotros, escríbenos a <a href="mailto:info@linkaloo.com">info@linkaloo.com</a>.</p>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/recuperar_password.php
+++ b/recuperar_password.php
@@ -38,5 +38,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/register.php
+++ b/register.php
@@ -100,5 +100,6 @@ document.getElementById('register-form').addEventListener('submit', function(e) 
 });
 </script>
 <?php endif; ?>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/restablecer_password.php
+++ b/restablecer_password.php
@@ -53,5 +53,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/seleccion_tableros.php
+++ b/seleccion_tableros.php
@@ -78,5 +78,6 @@ include 'header.php';
     </form>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/tablero.php
+++ b/tablero.php
@@ -185,5 +185,6 @@ include 'header.php';
     <p>No hay links en este tablero.</p>
 <?php endif; ?>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/tablero_publico.php
+++ b/tablero_publico.php
@@ -84,5 +84,6 @@ include 'header.php';
 <p>No hay links en este tablero.</p>
 <?php endif; ?>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>

--- a/tableros.php
+++ b/tableros.php
@@ -72,5 +72,6 @@ include 'header.php';
     </div>
 </div>
 </div>
+<?php include 'firebase_scripts.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable `firebase_scripts.php` snippet with the Firebase initialization module
- include the Firebase module at the end of each PHP page body so the SDK loads site-wide
- embed the Firebase module directly in `offline.html` to cover the static offline view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d512305de0832caef576c29c770acc