### PR TITLE
Allow saving links without a title

### DIFF
--- a/save_link.php
+++ b/save_link.php
@@ -28,11 +28,11 @@ $categoryId = isset($requestData['categoria_id']) ? (int) $requestData['categori
 $url        = trim($requestData['url'] ?? '');
 $title      = trim($requestData['titulo'] ?? '');
 
-if ($userId <= 0 || $categoryId <= 0 || $url === '' || $title === '') {
+if ($userId <= 0 || $categoryId <= 0 || $url === '') {
     http_response_code(400);
     echo json_encode([
         'success' => false,
-        'error'   => 'Debe proporcionar usuario_id, categoria_id, url y titulo.',
+        'error'   => 'Debe proporcionar usuario_id, categoria_id y url.',
     ], JSON_UNESCAPED_UNICODE);
     exit;
 }
@@ -46,7 +46,9 @@ if (!filter_var($url, FILTER_VALIDATE_URL)) {
     exit;
 }
 
-if (mb_strlen($title) > 50) {
+if ($title === '') {
+    $title = null;
+} elseif (mb_strlen($title) > 50) {
     $title = mb_substr($title, 0, 50);
 }
 


### PR DESCRIPTION
## Summary
- stop requiring a title when saving a link through save_link.php
- normalize empty titles to null before inserting in the database

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa5c4f364832cae15c458d49cb5b5