### PR TITLE
Implementa consentimiento de cookies GDPR/ePrivacy con panel granular

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3,6 +3,118 @@ document.addEventListener('DOMContentLoaded', () => {
     feather.replace();
   }
   const params = new URLSearchParams(window.location.search);
+  const cookieConsentKey = 'linkaloo_cookie_consent';
+  const cookieConsentVersion = '2026-03-02';
+
+  const saveConsent = (consent) => {
+    const payload = {
+      version: cookieConsentVersion,
+      timestamp: new Date().toISOString(),
+      consent
+    };
+    try {
+      localStorage.setItem(cookieConsentKey, JSON.stringify(payload));
+    } catch (_) {}
+    document.cookie = `linkaloo_cookie_consent=${encodeURIComponent(payload.timestamp)}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
+    window.dispatchEvent(new CustomEvent('linkaloo:cookie-consent-updated', { detail: payload }));
+  };
+
+  const getStoredConsent = () => {
+    try {
+      const raw = localStorage.getItem(cookieConsentKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || !parsed.consent) return null;
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  };
+
+  const consentRoot = document.getElementById('cookie-consent-root');
+  const consentModal = consentRoot ? consentRoot.querySelector('[data-cookie-modal]') : null;
+  const categoryInputs = consentRoot ? consentRoot.querySelectorAll('[data-cookie-category]') : [];
+
+  const applyConsentToUi = (stored) => {
+    const defaults = { preferences: false, analytics: false, marketing: false };
+    const current = stored && stored.consent ? { ...defaults, ...stored.consent } : defaults;
+    categoryInputs.forEach((input) => {
+      input.checked = Boolean(current[input.dataset.cookieCategory]);
+    });
+  };
+
+  const hideBanner = () => {
+    if (consentRoot) {
+      consentRoot.hidden = true;
+      consentModal.hidden = true;
+    }
+  };
+
+  const openPreferences = () => {
+    if (!consentRoot) return;
+    consentRoot.hidden = false;
+    consentModal.hidden = false;
+  };
+
+  const closePreferences = () => {
+    if (consentModal) {
+      consentModal.hidden = true;
+    }
+  };
+
+  if (consentRoot) {
+    const stored = getStoredConsent();
+    applyConsentToUi(stored);
+    if (!stored || stored.version !== cookieConsentVersion) {
+      consentRoot.hidden = false;
+    }
+
+    consentRoot.querySelectorAll('[data-cookie-action]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.cookieAction;
+        if (action === 'accept-all') {
+          saveConsent({ necessary: true, preferences: true, analytics: true, marketing: true });
+          hideBanner();
+        }
+        if (action === 'reject-all') {
+          saveConsent({ necessary: true, preferences: false, analytics: false, marketing: false });
+          hideBanner();
+        }
+        if (action === 'open-preferences') {
+          openPreferences();
+        }
+        if (action === 'close-preferences') {
+          closePreferences();
+          if (stored) hideBanner();
+        }
+        if (action === 'save-preferences') {
+          const consent = { necessary: true };
+          categoryInputs.forEach((input) => {
+            consent[input.dataset.cookieCategory] = input.checked;
+          });
+          saveConsent(consent);
+          hideBanner();
+        }
+      });
+    });
+  }
+
+  document.querySelectorAll('.open-cookie-preferences').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      openPreferences();
+    });
+  });
+
+  window.CookieConsentManager = {
+    getConsent: getStoredConsent,
+    openPreferences,
+    revokeAll: () => {
+      saveConsent({ necessary: true, preferences: false, analytics: false, marketing: false });
+      applyConsentToUi({ consent: { preferences: false, analytics: false, marketing: false } });
+      openPreferences();
+    }
+  };
+
   const toggle = document.querySelector('.menu-toggle');
   const menu = document.querySelector('.top-menu ul');
   if (toggle && menu) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -314,3 +314,28 @@ textarea {
   .info-card{padding:24px 20px;gap:24px;}
   .info-card ul li{padding-left:48px;}
 }
+
+/* Cookie consent */
+.settings-submenu .open-cookie-preferences{background:none;border:none;color:inherit;font:inherit;cursor:pointer;padding:0;text-align:left;}
+.cookie-consent{position:fixed;inset:auto 16px 16px;z-index:1200;display:flex;flex-direction:column;gap:12px;align-items:flex-end;}
+.cookie-banner{max-width:760px;background:#0f2238;color:#fff;border-radius:16px;padding:20px;box-shadow:0 12px 30px rgba(0,0,0,0.24);}
+.cookie-banner-title{margin:0 0 8px;font-size:1.1rem;font-weight:700;}
+.cookie-banner-text{margin:0 0 16px;line-height:1.5;color:#e3edf8;}
+.cookie-banner-actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:flex-end;}
+.cookie-btn{border:none;border-radius:999px;padding:10px 16px;font-family:'Rambla',sans-serif;cursor:pointer;}
+.cookie-btn-primary{background:#1DA1F2;color:#fff;}
+.cookie-btn-secondary{background:#e9eef5;color:#0f2238;}
+.cookie-modal{position:fixed;inset:0;background:rgba(5,13,24,0.65);display:grid;place-items:center;padding:16px;z-index:1300;}
+.cookie-modal-card{width:min(700px,100%);max-height:90vh;overflow:auto;background:#fff;border-radius:20px;padding:24px;display:flex;flex-direction:column;gap:14px;}
+.cookie-modal-card h2,.cookie-modal-card p{margin:0;}
+.cookie-category{display:flex;justify-content:space-between;gap:14px;align-items:flex-start;background:#f5f8fa;border-radius:14px;padding:14px;}
+.cookie-category p{font-size:0.95rem;color:#3b3d4a;}
+.cookie-category input{width:20px;height:20px;margin-top:8px;}
+.cookie-fixed-label{font-size:0.85rem;color:#1DA1F2;font-weight:700;white-space:nowrap;}
+
+@media (max-width:600px){
+  .cookie-consent{inset:auto 10px 10px;}
+  .cookie-banner{padding:16px;}
+  .cookie-banner-actions{justify-content:stretch;}
+  .cookie-banner-actions .cookie-btn{flex:1;}
+}

--- a/cookie_consent.php
+++ b/cookie_consent.php
@@ -1,0 +1,55 @@
+<div id="cookie-consent-root" class="cookie-consent" hidden>
+    <div class="cookie-banner" role="dialog" aria-live="polite" aria-label="Preferencias de cookies">
+        <p class="cookie-banner-title">Configuración de cookies</p>
+        <p class="cookie-banner-text">Usamos cookies estrictamente necesarias para el funcionamiento del sitio y, con tu consentimiento explícito, cookies de preferencias, analíticas y marketing.</p>
+        <div class="cookie-banner-actions">
+            <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-action="reject-all">Rechazar no esenciales</button>
+            <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-action="open-preferences">Elegir por categorías</button>
+            <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-action="accept-all">Aceptar todas</button>
+        </div>
+    </div>
+
+    <div class="cookie-modal" data-cookie-modal hidden>
+        <div class="cookie-modal-card" role="dialog" aria-modal="true" aria-label="Panel de configuración de cookies">
+            <h2>Preferencias de cookies</h2>
+            <p>Puedes cambiar tu consentimiento en cualquier momento. Las cookies necesarias siempre están activas porque permiten iniciar sesión y proteger tu cuenta.</p>
+
+            <div class="cookie-category cookie-category-required">
+                <div>
+                    <strong>Estrictamente necesarias</strong>
+                    <p>Autenticación, seguridad y funcionamiento básico del sitio.</p>
+                </div>
+                <span class="cookie-fixed-label">Siempre activas</span>
+            </div>
+
+            <label class="cookie-category">
+                <div>
+                    <strong>Preferencias</strong>
+                    <p>Recuerdan opciones de visualización y ajustes del usuario.</p>
+                </div>
+                <input type="checkbox" data-cookie-category="preferences">
+            </label>
+
+            <label class="cookie-category">
+                <div>
+                    <strong>Analíticas</strong>
+                    <p>Nos ayudan a entender cómo se usa linkaloo para mejorar el servicio.</p>
+                </div>
+                <input type="checkbox" data-cookie-category="analytics">
+            </label>
+
+            <label class="cookie-category">
+                <div>
+                    <strong>Marketing</strong>
+                    <p>Permiten campañas y medición publicitaria de terceros.</p>
+                </div>
+                <input type="checkbox" data-cookie-category="marketing">
+            </label>
+
+            <div class="cookie-banner-actions">
+                <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-action="close-preferences">Cancelar</button>
+                <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-action="save-preferences">Guardar preferencias</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/cookies.php
+++ b/cookies.php
@@ -11,9 +11,15 @@
 
         <div class="info-note">
             <strong>Gestiona tus preferencias</strong>
-            <span>Al continuar navegando aceptas su uso. Puedes revisar todos los detalles o ajustar la configuración en nuestra <a href="/politica_cookies.php">Política de cookies</a>.</span>
+            <span>Solo se activan cookies no esenciales cuando das tu consentimiento explícito. Puedes revisar los detalles en la <a href="/politica_cookies.php">Política de cookies</a> o gestionar tus preferencias ahora mismo.</span>
         </div>
     </div>
+
+        <div class="info-note">
+            <strong>Cambiar o retirar consentimiento</strong>
+            <span>Puedes modificar o revocar tu elección en cualquier momento desde el panel de cookies.</span>
+            <button type="button" class="cookie-btn cookie-btn-primary open-cookie-preferences">Configurar cookies</button>
+        </div>
 </div>
 </div>
 </body>

--- a/header.php
+++ b/header.php
@@ -49,6 +49,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                 <ul class="settings-submenu">
                     <li><a href="/cookies.php">Cookies</a></li>
                     <li><a href="/politica_cookies.php">Política de cookies</a></li>
+                    <li><button type="button" class="open-cookie-preferences">Configurar cookies</button></li>
                     <li><a href="/condiciones_servicio.php">Condiciones de servicio</a></li>
                     <li><a href="/politica_privacidad.php">Política de privacidad</a></li>
                     <li><a href="/quienes_somos.php">Quiénes somos</a></li>
@@ -57,4 +58,5 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
         </ul>
     </nav>
 </header>
+<?php include "cookie_consent.php"; ?>
 <div class="content">

--- a/header_top_favolinks.php
+++ b/header_top_favolinks.php
@@ -49,6 +49,7 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
                 <ul class="settings-submenu">
                     <li><a href="/cookies.php">Cookies</a></li>
                     <li><a href="/politica_cookies.php">Política de cookies</a></li>
+                    <li><button type="button" class="open-cookie-preferences">Configurar cookies</button></li>
                     <li><a href="/condiciones_servicio.php">Condiciones de servicio</a></li>
                     <li><a href="/politica_privacidad.php">Política de privacidad</a></li>
                     <li><a href="/quienes_somos.php">Quiénes somos</a></li>
@@ -58,4 +59,5 @@ $jsVersion  = filemtime(__DIR__ . '/assets/main.js');
     </nav>
 </header>
 -->
+<?php include "cookie_consent.php"; ?>
 <div class="content">

--- a/politica_cookies.php
+++ b/politica_cookies.php
@@ -25,42 +25,70 @@
 
         <section class="info-section">
             <h2>3. Lista de cookies y finalidades</h2>
-            <p>Estas son cookies habituales en linkaloo y en servicios de terceros que pueden activarse según tu configuración. Revisamos esta tabla periódicamente para mantenerla actualizada.</p>
+            <p>Estas son las cookies que usa actualmente linkaloo o que podrían activarse según la categoría de consentimiento que selecciones. Incluimos nombre, finalidad, proveedor, duración y si son de terceros.</p>
             <table class="legal-table">
                 <thead>
                     <tr>
-                        <th>Nombre de cookie</th>
-                        <th>Proveedor</th>
+                        <th>Nombre</th>
                         <th>Finalidad</th>
-                        <th>Tipo</th>
+                        <th>Proveedor</th>
                         <th>Duración</th>
+                        <th>Tercero</th>
+                        <th>Categoría</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td>_session_id</td>
+                        <td>PHPSESSID</td>
+                        <td>Identificar la sesión del usuario para mantener login, seguridad y navegación interna.</td>
                         <td>linkaloo.com</td>
-                        <td>Mantener sesión iniciada y asegurar el funcionamiento básico de la cuenta.</td>
-                        <td>Técnica (necesaria)</td>
                         <td>Sesión</td>
+                        <td>No</td>
+                        <td>Estrictamente necesaria</td>
                     </tr>
                     <tr>
-                        <td>_ga</td>
-                        <td>google.com</td>
-                        <td>Recopilar datos agregados de navegación para analítica y mejora del servicio.</td>
-                        <td>Analítica (previo consentimiento)</td>
-                        <td>2 años</td>
+                        <td>linkaloo_remember</td>
+                        <td>Recordar la autenticación del usuario cuando activa la opción “recordarme”.</td>
+                        <td>linkaloo.com</td>
+                        <td>30 días</td>
+                        <td>No</td>
+                        <td>Estrictamente necesaria</td>
+                    </tr>
+                    <tr>
+                        <td>linkaloo_cookie_consent</td>
+                        <td>Guardar las preferencias de consentimiento para no volver a mostrar el banner en cada visita.</td>
+                        <td>linkaloo.com</td>
+                        <td>12 meses</td>
+                        <td>No</td>
+                        <td>Estrictamente necesaria</td>
+                    </tr>
+                    <tr>
+                        <td>_ga*</td>
+                        <td>Medición agregada de uso del sitio y análisis estadístico de navegación.</td>
+                        <td>Google LLC</td>
+                        <td>Hasta 2 años</td>
+                        <td>Sí</td>
+                        <td>Analítica (solo con consentimiento)</td>
                     </tr>
                     <tr>
                         <td>_gid</td>
-                        <td>google.com</td>
-                        <td>Distinguir sesiones de uso con fines estadísticos.</td>
-                        <td>Analítica (previo consentimiento)</td>
+                        <td>Distinguir sesiones de navegación para estadísticas de uso.</td>
+                        <td>Google LLC</td>
                         <td>24 horas</td>
+                        <td>Sí</td>
+                        <td>Analítica (solo con consentimiento)</td>
+                    </tr>
+                    <tr>
+                        <td>_fbp / fr</td>
+                        <td>Medir rendimiento de campañas y personalización publicitaria en plataformas sociales.</td>
+                        <td>Meta Platforms, Inc.</td>
+                        <td>Hasta 3 meses</td>
+                        <td>Sí</td>
+                        <td>Marketing (solo con consentimiento)</td>
                     </tr>
                 </tbody>
             </table>
-            <p><em>Nota:</em> la lista puede cambiar si incorporamos nuevas funcionalidades o proveedores externos.</p>
+            <p><em>Nota:</em> si añadimos nuevos proveedores o cookies, actualizaremos esta política y te volveremos a solicitar consentimiento cuando sea necesario.</p>
         </section>
 
         <section class="info-section">
@@ -74,8 +102,14 @@
 
         <section class="info-section">
             <h2>5. ¿Cómo puedes gestionar o retirar el consentimiento?</h2>
-            <p>Puedes configurar tus preferencias en cualquier momento mediante el panel de configuración de cookies (disponible en el banner o en la sección “Configurar cookies”) y también desde las opciones de tu navegador para bloquear, eliminar o restringir cookies.</p>
+            <p>Registramos tu elección de consentimiento en localStorage y en una cookie técnica de preferencia para poder demostrar la trazabilidad del consentimiento y respetar tu decisión en visitas posteriores. Puedes configurar, retirar o modificar tus preferencias en cualquier momento desde el botón “Configurar cookies” del sitio o desde el banner inicial.</p>
         </section>
+
+        <div class="info-note">
+            <strong>Panel de consentimiento</strong>
+            <span>Haz clic para revisar o cambiar ahora tus elecciones por categoría.</span>
+            <button type="button" class="cookie-btn cookie-btn-primary open-cookie-preferences">Configurar cookies</button>
+        </div>
 
         <section class="info-section">
             <h2>6. Transferencias internacionales</h2>


### PR DESCRIPTION
### Motivation
- Asegurar que el sitio cumple con RGPD y la Directiva ePrivacy mostrando un banner de consentimiento explícito y permitiendo decisiones granulares por categorías.  
- Proveer un mecanismo reutilizable y accesible para que el usuario acepte, rechace o configure categorías de cookies desde cualquier página.  
- Registrar la elección del usuario para respetarla en visitas posteriores y ofrecer una forma de revocarla o modificarla fácilmente.

### Description
- Añadido componente visual `cookie_consent.php` que incluye un banner (Aceptar todas / Rechazar no esenciales / Elegir por categorías) y un modal para seleccionar categorías (`preferences`, `analytics`, `marketing`).  
- Integrado el componente en las plantillas globales incluyendo `cookie_consent.php` desde `header.php` y `header_top_favolinks.php` y añadido el acceso `Configurar cookies` en el menú de ajustes.  
- Implementada la lógica frontend en `assets/main.js` para guardar/leer consentimiento en `localStorage` y en una cookie técnica `linkaloo_cookie_consent`, con versionado (`cookieConsentVersion`), handlers para acciones del banner y API pública `window.CookieConsentManager` (consultar, reabrir y revocar).  
- Añadidos estilos responsive en `assets/style.css` para el banner y modal de consentimiento.  
- Actualizada `politica_cookies.php` con una tabla más detallada (nombre, finalidad, proveedor, duración, tercero y categoría) y texto que explica el registro del consentimiento y la posibilidad de revocarlo.  
- Ajustada `cookies.php` para eliminar el mensaje implícito de «seguir navegando = consentir» y ofrecer un botón que abre el panel de configuración.

### Testing
- Ejecutado `php -l` sobre `header.php`, `header_top_favolinks.php`, `cookies.php`, `politica_cookies.php` y `cookie_consent.php` y todos pasaron sin errores.  
- Ejecutado `npm run lint:css` (stylelint) y la hoja de estilos quedó sin errores tras corrección de las reglas detectadas inicialmente.  
- Intenté una verificación visual automática con Playwright contra un servidor PHP local para capturar la página `cookies.php`, pero la ejecución devolvió `net::ERR_EMPTY_RESPONSE` en este entorno, por lo que no se pudo generar la captura en esta ejecución.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d18ded70832ca0b54d010f59aa65)