### PR TITLE
Fix cookie preference overlay showing while hidden

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -318,6 +318,7 @@ textarea {
 /* Cookie consent */
 .settings-submenu .open-cookie-preferences{background:none;border:none;color:inherit;font:inherit;cursor:pointer;padding:0;text-align:left;}
 .cookie-consent{position:fixed;inset:auto 16px 16px;z-index:1200;display:flex;flex-direction:column;gap:12px;align-items:flex-end;}
+.cookie-consent[hidden]{display:none;}
 .cookie-banner{max-width:760px;background:#0f2238;color:#fff;border-radius:16px;padding:20px;box-shadow:0 12px 30px rgba(0,0,0,0.24);}
 .cookie-banner-title{margin:0 0 8px;font-size:1.1rem;font-weight:700;}
 .cookie-banner-text{margin:0 0 16px;line-height:1.5;color:#e3edf8;}
@@ -326,6 +327,7 @@ textarea {
 .cookie-btn-primary{background:#1DA1F2;color:#fff;}
 .cookie-btn-secondary{background:#e9eef5;color:#0f2238;}
 .cookie-modal{position:fixed;inset:0;background:rgba(5,13,24,0.65);display:grid;place-items:center;padding:16px;z-index:1300;}
+.cookie-modal[hidden]{display:none;}
 .cookie-modal-card{width:min(700px,100%);max-height:90vh;overflow:auto;background:#fff;border-radius:20px;padding:24px;display:flex;flex-direction:column;gap:14px;}
 .cookie-modal-card h2,.cookie-modal-card p{margin:0;}
 .cookie-category{display:flex;justify-content:space-between;gap:14px;align-items:flex-start;background:#f5f8fa;border-radius:14px;padding:14px;}


### PR DESCRIPTION
### Motivation
- The cookie preferences panel and its backdrop could remain visible even when the UI set them to `hidden`, producing an unwanted gray overlay.
- Ensure hidden consent UI elements are removed from layout/rendering so the page content is not obscured.

### Description
- Add explicit CSS rules to hide elements with the `hidden` attribute: `.cookie-consent[hidden]{display:none;}` and `.cookie-modal[hidden]{display:none;}` in `assets/style.css`.
- This change makes the consent root and the preferences modal fully non-rendering when they are hidden, avoiding the gray overlay issue.

### Testing
- Ran `node --check assets/main.js` and it completed successfully.
- Executed an automated Playwright script against `http://127.0.0.1:8000/` which loaded the page, cleared stored consent, and produced a screenshot showing the consent UI hidden as expected (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d4ddc67c832c806303e45603194d)