### PR TITLE
Limitar el popup de cookies a cpanel.php

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -31,7 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  const consentRoot = document.getElementById('cookie-consent-root');
+  const isCpanelView = /\/cpanel\.php$/.test(window.location.pathname);
+  const consentRoot = isCpanelView ? document.getElementById('cookie-consent-root') : null;
   const consentModal = consentRoot ? consentRoot.querySelector('[data-cookie-modal]') : null;
   const categoryInputs = consentRoot ? consentRoot.querySelectorAll('[data-cookie-category]') : [];
 


### PR DESCRIPTION
### Motivation
- Evitar que el popup/modal de consentimiento de cookies aparezca en vistas que no sean el panel de control (`/cpanel.php`) durante las pruebas.

### Description
- En `assets/main.js` se añadió la comprobación `isCpanelView = /\/cpanel\.php$/.test(window.location.pathname)` y `consentRoot` solo se resuelve cuando `isCpanelView` es verdadero, deshabilitando así la inicialización del popup en otras rutas.

### Testing
- `node --check assets/main.js` ejecutado y sin errores.
- Se arrancó un servidor con `php -S 0.0.0.0:8000` y se ejecutó un script Playwright que navegó a `http://127.0.0.1:8000/` y tomó `artifacts/home-no-popup.png`, confirmando que no aparece el popup en la vista de inicio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d5c8b63c832ca0d66005aa936d46)