### PR TITLE
Initialize cookie consent UI on any page (fix /cookies.php)

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -31,8 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  const isCpanelView = /\/cpanel\.php$/.test(window.location.pathname);
-  const consentRoot = isCpanelView ? document.getElementById('cookie-consent-root') : null;
+  const consentRoot = document.getElementById('cookie-consent-root');
   const consentModal = consentRoot ? consentRoot.querySelector('[data-cookie-modal]') : null;
   const categoryInputs = consentRoot ? consentRoot.querySelectorAll('[data-cookie-category]') : [];
 


### PR DESCRIPTION
### Motivation
- The cookie preferences modal was only initialized for `cpanel.php`, which prevented the “Configurar cookies” button on `/cookies.php` from opening the preferences panel, so the consent UI must initialize on any page that includes `#cookie-consent-root`.

### Description
- Remove the `cpanel.php` route guard and initialize the consent UI when `#cookie-consent-root` exists by updating `assets/main.js` to use `const consentRoot = document.getElementById('cookie-consent-root');`.

### Testing
- Ran `php -l cookies.php` and `php -l header.php` (both reported no syntax errors), and attempted an automated Playwright screenshot to validate the UI which failed due to a Chromium crash (SIGSEGV) in the test container, so interactive verification could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69f67f028832cbb33cbd4c9f8b8bd)