### PR TITLE
docs: agregar FAQ del proyecto y enlazarla en índices

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,6 @@ Los estilos y patrones de arquitectura principales se describen en el
 - [docs/arquitectura.md](docs/arquitectura.md) – descripción de capas, flujos de datos e integraciones externas.
 - [docs/configuracion.md](docs/configuracion.md) – variables de entorno, ajustes avanzados y consejos de despliegue.
 - [docs/progreso.md](docs/progreso.md) – resumen del estado actual, logros y próximos pasos.
+- [docs/faq.md](docs/faq.md) – preguntas frecuentes para resolver dudas operativas y técnicas.
 - [docs/resumen_ejecutivo.md](docs/resumen_ejecutivo.md) – visión rápida para entender el producto, su
   público objetivo y cómo operarlo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ instrucciones para usuarios finales y la referencia de los endpoints disponibles
 | [configuracion.md](configuracion.md) | Variables de entorno recomendadas, requisitos de OAuth/reCAPTCHA y tareas de mantenimiento. |
 | [endpoints.md](endpoints.md) | Referencia de los scripts PHP que exponen respuestas JSON o sirven contenido público. |
 | [progreso.md](progreso.md) | Resumen del estado actual del proyecto, funcionalidades cubiertas y próximos pasos sugeridos. |
+| [faq.md](faq.md) | Preguntas frecuentes de instalación, operación y resolución de dudas comunes. |
 
 ## Flujo general del proyecto
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,96 @@
+# FAQ de linkaloo
+
+## ¿Qué es linkaloo y para qué sirve?
+
+linkaloo es una aplicación web para guardar enlaces en tableros temáticos, buscarlos rápidamente y
+compartir tableros o enlaces individuales con otras personas.
+
+## ¿Qué necesito para ejecutarlo en local?
+
+- PHP 8.1+
+- MySQL 8+
+- Extensiones de PHP: PDO (MySQL), cURL, mbstring, DOM, GD y JSON
+- Node.js 18+ (solo para herramientas de lint en desarrollo)
+
+Consulta la guía completa en [instalacion.md](instalacion.md).
+
+## ¿Dónde configuro la conexión a la base de datos?
+
+En [`config.php`](../config.php). También puedes revisar recomendaciones de variables y despliegue en
+[configuracion.md](configuracion.md).
+
+## ¿Cómo creo el esquema de base de datos?
+
+Importa [`database.sql`](../database.sql) en una base vacía:
+
+```bash
+mysql -u TU_USUARIO -p TU_BD < database.sql
+```
+
+## ¿Cómo verifico rápidamente que todo está bien?
+
+Desde la raíz del repositorio:
+
+```bash
+php -l config.php panel.php move_link.php load_links.php
+node --check assets/main.js
+npm run lint:css
+```
+
+## ¿Qué flujo mínimo debo probar tras instalar?
+
+1. Registro o login.
+2. Creación de tablero.
+3. Alta de enlace en el tablero.
+4. Filtrado/búsqueda en panel.
+5. Compartición de enlace o tablero.
+
+## ¿Qué endpoints se usan desde el front-end para acciones dinámicas?
+
+Los más frecuentes son:
+
+- `load_links.php`
+- `move_link.php`
+- `delete_link.php`
+- `load_public_links.php`
+
+La referencia funcional de parámetros y respuestas está en [endpoints.md](endpoints.md).
+
+## ¿Cómo funciona la compartición?
+
+El sistema combina:
+
+- **Web Share API** (cuando el navegador la soporta)
+- **AddToAny** como alternativa
+- Tableros públicos con token mediante `tablero_publico.php`
+
+## ¿Dónde se guardan favicons e imágenes de fichas?
+
+- Favicons locales: `local_favicons/`
+- Imágenes/fichas de enlaces: `fichas/`
+
+Estas rutas deben tener permisos de escritura para el usuario del servidor web.
+
+## ¿Cómo restablezco una contraseña?
+
+Usando el flujo de:
+
+1. `recuperar_password.php`
+2. `restablecer_password.php`
+3. `cambiar_password.php`
+
+El correo de recuperación debe estar bien configurado en `config.php`.
+
+## ¿Cuál es el punto de entrada principal de la interfaz autenticada?
+
+`panel.php`, desde donde se accede a gestión de tableros, enlaces y compartición.
+
+## ¿Hay soporte para OAuth?
+
+Sí. El proyecto incluye flujo OAuth con Google (`oauth.php` y `oauth2callback.php`).
+
+## ¿Qué documento leer primero si voy a tocar código?
+
+- Primero: [guia_rapida.md](guia_rapida.md)
+- Después: [manual_tecnico.md](manual_tecnico.md)
+- Finalmente: [arquitectura.md](arquitectura.md) y [estructura.md](estructura.md)


### PR DESCRIPTION
### Motivation
- Agregar un documento de preguntas frecuentes para resolver dudas rápidas sobre instalación, configuración y uso de la aplicación. 
- Mejorar la descubribilidad de la documentación práctica enlazando la FAQ desde los índices principales. 

### Description
- Se creó `docs/faq.md` con preguntas frecuentes sobre instalación, requisitos, esquema de base de datos, verificación rápida, endpoints, compartición y flujos de operación. 
- Se actualizó `docs/README.md` para incluir `faq.md` en la tabla de contenidos. 
- Se actualizó `README.md` para enlazar `docs/faq.md` en la sección de “Documentación ampliada”. 

### Testing
- Se ejecutó `node --check assets/main.js` y la comprobación finalizó sin errores. 
- Se ejecutó `npm run lint:css` (Stylelint sobre `assets/style.css`) y la comprobación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69b27c544832c8fcf49f191e3c018)