### PR TITLE
Uniformiza paginación del listado para cargar 500 resultados por lote

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -303,7 +303,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const sentinel = document.createElement('div');
       sentinel.className = 'load-more-sentinel';
       boardLazyContainer.appendChild(sentinel);
-      const limit = mode === 'public' ? 50 : 100;
+      const limit = 500;
       const catId = boardLazyContainer.dataset.cat;
       const token = boardLazyContainer.dataset.token;
       let loadingMore = false;


### PR DESCRIPTION
### Motivation
- Unificar el tamaño de los bloques de paginación del listado en scroll infinito para reducir la cantidad de solicitudes y evitar límites distintos por modo.

### Description
- Se modificó `assets/main.js` para cambiar la variable `limit` de `mode === 'public' ? 50 : 100` a `500`, de modo que las peticiones a `load_links.php` y `load_public_links.php` pidan hasta 500 resultados por lote.

### Testing
- Ejecutado `node --check assets/main.js` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6e8e150832cb0612ae64f86e99a)