### PR TITLE
Limitar a 500 enlaces: aplicar LIMIT y normalizar data-total en tableros

### DIFF
--- a/_tablero_publico.php
+++ b/_tablero_publico.php
@@ -24,13 +24,12 @@ $totalStmt = $pdo->prepare('SELECT COUNT(*) FROM links WHERE categoria_id = ?');
 $totalStmt->execute([$board['id']]);
 $totalLinks = (int)$totalStmt->fetchColumn();
 $linksQuery = 'SELECT url, titulo, descripcion, imagen FROM links WHERE categoria_id = ? ORDER BY id DESC';
-if(!$isMobile){
-    $linksQuery .= ' LIMIT 500';
-}
+$linksQuery .= ' LIMIT 500';
 $linksStmt = $pdo->prepare($linksQuery);
 $linksStmt->execute([$board['id']]);
 $links = $linksStmt->fetchAll();
 $loadedLinks = count($links);
+$totalLinks = min(500, $totalLinks);
 $descLimit = $isMobile ? 50 : 150;
 
 $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];

--- a/tablero.php
+++ b/tablero.php
@@ -113,14 +113,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 
 $isMobile = isMobile();
 $linksQuery = 'SELECT id, url, imagen FROM links WHERE usuario_id = ? AND categoria_id = ? ORDER BY id DESC';
-if(!$isMobile){
-    $linksQuery .= ' LIMIT 500';
-}
+$linksQuery .= ' LIMIT 500';
 $linksStmt = $pdo->prepare($linksQuery);
 $linksStmt->execute([$user_id, $id]);
 $links = $linksStmt->fetchAll();
 $loadedLinks = count($links);
-$totalLinks = (int)($board['total_links'] ?? $loadedLinks);
+$totalLinks = min(500, (int)($board['total_links'] ?? $loadedLinks));
 
 $creado = $board['creado_en'] ? date('Y-m', strtotime($board['creado_en'])) : '';
 $modificado = $board['modificado_en'] ? date('Y-m', strtotime($board['modificado_en'])) : '';


### PR DESCRIPTION
### Motivation
- Evitar que la vista de tableros (públicos y privados) cargue más de 500 links y que el paginador/lazy-load se descoordine cuando el `data-total` del frontend supera el tope aplicado en la consulta SQL.

### Description
- En `tablero.php` se aplica `LIMIT 500` de forma incondicional a la consulta inicial de links y se normaliza `data-total` con `min(500, ...)` para exponer como máximo 500 al frontend.
- En `_tablero_publico.php` se aplica el mismo `LIMIT 500` a la consulta inicial y se ajusta `data-total` con `min(500, ...)` para mantener comportamiento consistente entre público/privado.
- Estos cambios alinean la consulta servidor-side con la lógica de lazy-loading en `assets/main.js` que asume un tope para activar el sentinel y cargar más.
- Archivos modificados: `tablero.php` y `_tablero_publico.php`.

### Testing
- Ejecutado `php -l tablero.php` y `php -l _tablero_publico.php`, ambos sin errores de sintaxis (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a7d24fcc832c9d77376baa1ad776)