### PR TITLE
Ajusta export CSV para dejar ID sin comillas

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -316,14 +316,20 @@ if (isset($_GET['export_welcome_csv'])) {
     fwrite($output, "\xEF\xBB\xBF");
     fputcsv($output, ['id', 'nombre', 'email', 'creado_en', 'actualizado_en']);
 
+    $escapeCsv = static function (string $value): string {
+        return '"' . str_replace('"', '""', $value) . '"';
+    };
+
     foreach ($welcomeUsers as $user) {
-        fputcsv($output, [
-            (int) ($user['id'] ?? 0),
-            (string) ($user['nombre'] ?? ''),
-            (string) ($user['email'] ?? ''),
-            (string) ($user['creado_en'] ?? ''),
-            (string) ($user['actualizado_en'] ?? ''),
-        ]);
+        $row = [
+            (string) ((int) ($user['id'] ?? 0)),
+            $escapeCsv((string) ($user['nombre'] ?? '')),
+            $escapeCsv((string) ($user['email'] ?? '')),
+            $escapeCsv((string) ($user['creado_en'] ?? '')),
+            $escapeCsv((string) ($user['actualizado_en'] ?? '')),
+        ];
+
+        fwrite($output, implode(',', $row) . "\n");
     }
 
     fclose($output);


### PR DESCRIPTION
### Motivation
- El CSV de usuarios D0 debe entregar la columna `id` sin comillas para cumplir con consumidores que esperan un valor numérico sin comillas, manteniendo el resto de columnas escapadas correctamente.

### Description
- Reemplacé el uso de `fputcsv` para las filas de datos por una construcción manual de línea CSV que escribe `id` sin comillas y aplica escape explícito a las columnas de texto. 
- Añadí el cierre `$escapeCsv` que escapa comillas dobles según la especificación CSV (`"` -> `""`) y las envuelve en `"` para `nombre`, `email`, `creado_en` y `actualizado_en`.
- Las cabeceras del CSV se mantienen con `fputcsv` y el archivo se envía con BOM UTF-8 y cabeceras HTTP apropiadas.

### Testing
- Se ejecutó la comprobación de sintaxis con `php -l linkaloo_stats.php` y no se detectaron errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6acbfcf78832c8c49c44fcac19176)