### PR TITLE
Quote ID column in D0 CSV export

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -322,7 +322,7 @@ if (isset($_GET['export_welcome_csv'])) {
 
     foreach ($welcomeUsers as $user) {
         $row = [
-            (string) ((int) ($user['id'] ?? 0)),
+            $escapeCsv((string) ((int) ($user['id'] ?? 0))),
             $escapeCsv((string) ($user['nombre'] ?? '')),
             $escapeCsv((string) ($user['email'] ?? '')),
             $escapeCsv((string) ($user['creado_en'] ?? '')),


### PR DESCRIPTION
### Motivation
- Ensure the D0 welcome-users CSV exported by `linkaloo_stats.php` writes the `ID` column between double quotes to match the escaping used for other columns.

### Description
- Apply the existing `$escapeCsv` function to the `id` field when building each CSV row in `linkaloo_stats.php`, so the `id` value is emitted with escaped double quotes like the other columns.

### Testing
- Ran `php -l linkaloo_stats.php` which returned `No syntax errors detected` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6adbe9014832cb69f143184bee566)