### PR TITLE
Quita comillas manuales en exportación CSV de usuarios D0

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -316,20 +316,16 @@ if (isset($_GET['export_welcome_csv'])) {
     fwrite($output, "\xEF\xBB\xBF");
     fputcsv($output, ['id', 'nombre', 'email', 'creado_en', 'actualizado_en']);
 
-    $escapeCsv = static function (string $value): string {
-        return '"' . str_replace('"', '""', $value) . '"';
-    };
-
     foreach ($welcomeUsers as $user) {
         $row = [
-            $escapeCsv((string) ((int) ($user['id'] ?? 0))),
-            $escapeCsv((string) ($user['nombre'] ?? '')),
-            $escapeCsv((string) ($user['email'] ?? '')),
-            $escapeCsv((string) ($user['creado_en'] ?? '')),
-            $escapeCsv((string) ($user['actualizado_en'] ?? '')),
+            (string) ((int) ($user['id'] ?? 0)),
+            (string) ($user['nombre'] ?? ''),
+            (string) ($user['email'] ?? ''),
+            (string) ($user['creado_en'] ?? ''),
+            (string) ($user['actualizado_en'] ?? ''),
         ];
 
-        fwrite($output, implode(',', $row) . "\n");
+        fputcsv($output, $row);
     }
 
     fclose($output);


### PR DESCRIPTION
### Motivation
- Evitar el escapado manual que envolvía en comillas todos los valores al generar el CSV y delegar el formateo al manejador estándar de PHP para producir CSV válido.

### Description
- En `linkaloo_stats.php` se removió la función `$escapeCsv`, se dejaron los valores como cadenas normales y se sustituyó `fwrite(implode(...))` por `fputcsv($output, $row)` para escribir cada fila.

### Testing
- Ejecuté `php -l linkaloo_stats.php` y la verificación de sintaxis pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6aed159c8832cb73072cea43d0ac0)