### PR TITLE
Fix CSV user export to avoid quoted user columns

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -267,6 +267,33 @@ function paginationItems(int $currentPage, int $totalPages): array
     return $pages;
 }
 
+/**
+ * Devuelve un valor plano para exportación sin comillas de encapsulado.
+ */
+function sanitizePlainExportValue(mixed $value): string
+{
+    $text = (string) ($value ?? '');
+
+    // Evita saltos de línea/tabs que rompen el formato del archivo.
+    $text = str_replace(["\r", "\n", "\t"], ' ', $text);
+
+    // Si el valor viene con comillas envolventes, las quita.
+    if (strlen($text) >= 2 && $text[0] === '"' && substr($text, -1) === '"') {
+        $text = substr($text, 1, -1);
+    }
+
+    return trim($text);
+}
+
+/**
+ * Escribe una fila CSV sin usar encapsulado por comillas.
+ */
+function writePlainCsvRow($output, array $row): void
+{
+    $cleanValues = array_map(static fn($value): string => sanitizePlainExportValue($value), $row);
+    fwrite($output, implode(',', $cleanValues) . "\n");
+}
+
 $pagination = paginationItems($currentPage, $totalPages);
 
 if (isset($_GET['export_welcome_csv'])) {
@@ -314,7 +341,7 @@ if (isset($_GET['export_welcome_csv'])) {
     }
 
     fwrite($output, "\xEF\xBB\xBF");
-    fputcsv($output, ['id', 'nombre', 'email', 'creado_en', 'actualizado_en']);
+    writePlainCsvRow($output, ['id', 'nombre', 'email', 'creado_en', 'actualizado_en']);
 
     foreach ($welcomeUsers as $user) {
         $row = [
@@ -325,7 +352,7 @@ if (isset($_GET['export_welcome_csv'])) {
             (string) ($user['actualizado_en'] ?? ''),
         ];
 
-        fputcsv($output, $row);
+        writePlainCsvRow($output, $row);
     }
 
     fclose($output);


### PR DESCRIPTION
### Motivation
- El exportador CSV de usuarios (`export_welcome_csv`) estaba generando campos de texto envueltos en comillas, lo que rompe el formato esperado para las columnas `nombre`, `email`, `creado_en` y `actualizado_en`.
- Se buscó producir un CSV más plano y predecible eliminando el encapsulado automático y limpiando saltos de línea o tabs que puedan romper el archivo.

### Description
- Añadidas las funciones `sanitizePlainExportValue` y `writePlainCsvRow` en `linkaloo_stats.php` para normalizar valores y escribir filas CSV sin el encapsulado por comillas. 
- Reemplazada la llamada a `fputcsv` por `writePlainCsvRow` tanto para la cabecera como para cada fila de datos en el exportador `export_welcome_csv` dentro de `linkaloo_stats.php`.
- `sanitizePlainExportValue` elimina `\r`, `\n`, `\t` y quita comillas envolventes si el valor ya viene entrecomillado, y `writePlainCsvRow` serializa las columnas con `implode(',', ...)` terminando en `\n`.

### Testing
- Ejecutado `php -l linkaloo_stats.php` para verificar sintaxis; el archivo no presentó errores.
- Se generó y revisó el diff del archivo `linkaloo_stats.php` para confirmar la sustitución de `fputcsv` por `writePlainCsvRow` y la inclusión de las nuevas funciones (cambios aplicados correctamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b23872ac832cab2daa505ed5446a)