### PR TITLE
Ensure CSV export sanitizes values as UTF-8

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -274,6 +274,11 @@ function sanitizePlainExportValue(mixed $value): string
 {
     $text = (string) ($value ?? '');
 
+    // Fuerza UTF-8 para evitar caracteres inválidos en la exportación.
+    if ($text !== '' && !mb_check_encoding($text, 'UTF-8')) {
+        $text = mb_convert_encoding($text, 'UTF-8', 'UTF-8, ISO-8859-1, WINDOWS-1252');
+    }
+
     // Evita saltos de línea/tabs que rompen el formato del archivo.
     $text = str_replace(["\r", "\n", "\t"], ' ', $text);
 


### PR DESCRIPTION
### Motivation
- Evitar que valores con codificaciones legacy rompan la descarga CSV y garantizar que el contenido coincida con el `charset=UTF-8` declarado en la respuesta.

### Description
- Se actualizó `sanitizePlainExportValue()` en `linkaloo_stats.php` para validar la codificación de cada campo con `mb_check_encoding(..., 'UTF-8')` y convertir los valores no UTF-8 a UTF-8 con `mb_convert_encoding(..., 'UTF-8', 'UTF-8, ISO-8859-1, WINDOWS-1252')`.
- La función sigue eliminando saltos de línea/tabs y comillas envolventes, y las cabeceras de exportación mantienen `Content-Type: text/csv; charset=UTF-8` y se escribe el BOM UTF-8 al inicio del flujo.

### Testing
- Se ejecutó `php -l linkaloo_stats.php` para comprobar la sintaxis y devolvió sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b55217d4832c824366cdf8c8d545)