### PR TITLE
Add D3 CSV export for users registered 3 days ago with no favolinks

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -301,7 +301,7 @@ function writePlainCsvRow($output, array $row): void
 
 $pagination = paginationItems($currentPage, $totalPages);
 
-if (isset($_GET['export_welcome_csv'])) {
+if (isset($_GET['export_welcome_csv']) || isset($_GET['export_d3_csv'])) {
     if (!$userCreatedColumn) {
         header('HTTP/1.1 500 Internal Server Error');
         header('Content-Type: text/plain; charset=UTF-8');
@@ -315,6 +315,10 @@ if (isset($_GET['export_welcome_csv'])) {
     $csvCreatedSelect = "u.`{$userCreatedColumn}`";
     $csvUpdatedSelect = $userUpdatedColumn ? "u.`{$userUpdatedColumn}`" : 'NULL';
 
+    $registrationDateCondition = isset($_GET['export_d3_csv'])
+        ? 'DATE(' . $csvCreatedSelect . ') = DATE_SUB(CURDATE(), INTERVAL 3 DAY)'
+        : 'DATE(' . $csvCreatedSelect . ') = CURDATE()';
+
     $welcomeUsersSql = "
         SELECT
             {$csvIdSelect} AS id,
@@ -324,7 +328,7 @@ if (isset($_GET['export_welcome_csv'])) {
             {$csvUpdatedSelect} AS actualizado_en
         FROM usuarios u
         LEFT JOIN links l ON l.usuario_id = u.id
-        WHERE DATE({$csvCreatedSelect}) = CURDATE()
+        WHERE {$registrationDateCondition}
         GROUP BY u.id, nombre, email, creado_en, actualizado_en
         HAVING COUNT(l.id) = 0
         ORDER BY u.id ASC
@@ -332,8 +336,9 @@ if (isset($_GET['export_welcome_csv'])) {
 
     $welcomeUsers = $pdo->query($welcomeUsersSql)->fetchAll(PDO::FETCH_ASSOC);
 
-    $todayForFile = (new DateTimeImmutable('today'))->format('Y-m-d');
-    $filename = 'D0_' . $todayForFile . '.csv';
+    $isD3Export = isset($_GET['export_d3_csv']);
+    $targetDate = new DateTimeImmutable($isD3Export ? 'today -3 days' : 'today');
+    $filename = ($isD3Export ? 'D3_' : 'D0_') . $targetDate->format('Y-m-d') . '.csv';
 
     header('Content-Type: text/csv; charset=UTF-8');
     header('Content-Disposition: attachment; filename="' . $filename . '"');
@@ -473,6 +478,7 @@ if (isset($_GET['export_welcome_csv'])) {
     <div class="header-row">
         <h1>Estadísticas de usuarios de Linkaloo</h1>
         <a class="welcome-export-btn" href="?export_welcome_csv=1">Descargar CSV usuarios D0 (sin favolinks)</a>
+        <a class="welcome-export-btn" href="?export_d3_csv=1">Descargar CSV usuarios D3 (sin favolinks)</a>
     </div>
 
     <div class="summary-grid">


### PR DESCRIPTION
### Motivation
- Proveer una exportación CSV para detectar usuarios que se registraron hace exactamente 3 días y aún no han guardado favolinks, para facilitar acciones de onboarding.

### Description
- Extendido el manejador de exportación en `linkaloo_stats.php` para aceptar el parámetro `export_d3_csv` además del existente `export_welcome_csv`.
- Añadida la condición de fecha dinámica `DATE_SUB(CURDATE(), INTERVAL 3 DAY)` cuando se solicita `export_d3_csv`, manteniendo el filtro `HAVING COUNT(l.id) = 0` para asegurar que el usuario no tiene favolinks.
- Generación dinámica del nombre de archivo con prefijos `D0_` o `D3_` según el tipo de export (`D3_YYYY-MM-DD.csv`).
- Agregado un nuevo botón UI en la cabecera: `Descargar CSV usuarios D3 (sin favolinks)` junto al botón D0 existente.

### Testing
- Ejecutado `php -l linkaloo_stats.php` para comprobar sintaxis PHP y el resultado fue exitoso (sin errores de sintaxis).
- Levantado un servidor de desarrollo con `php -S 0.0.0.0:8000` y validada la interfaz mediante un script de Playwright que accede con autenticación básica y captura una captura de pantalla mostrando el nuevo botón; la captura se generó correctamente (`artifacts/d3-button.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6c95f2de4832c9604ee26d7fdb326)