### PR TITLE
Update CSV export buttons to D0/D1/D3/D7 with download icon

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -301,7 +301,13 @@ function writePlainCsvRow($output, array $row): void
 
 $pagination = paginationItems($currentPage, $totalPages);
 
-if (isset($_GET['export_welcome_csv']) || isset($_GET['export_d3_csv']) || isset($_GET['export_d7_csv'])) {
+if (
+    isset($_GET['export_welcome_csv'])
+    || isset($_GET['export_d0_csv'])
+    || isset($_GET['export_d1_csv'])
+    || isset($_GET['export_d3_csv'])
+    || isset($_GET['export_d7_csv'])
+) {
     if (!$userCreatedColumn) {
         header('HTTP/1.1 500 Internal Server Error');
         header('Content-Type: text/plain; charset=UTF-8');
@@ -319,6 +325,8 @@ if (isset($_GET['export_welcome_csv']) || isset($_GET['export_d3_csv']) || isset
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') BETWEEN DATE_SUB(CURDATE(), INTERVAL 7 DAY) AND DATE_SUB(CURDATE(), INTERVAL 3 DAY)';
     } elseif (isset($_GET['export_d3_csv'])) {
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') = DATE_SUB(CURDATE(), INTERVAL 3 DAY)';
+    } elseif (isset($_GET['export_d1_csv'])) {
+        $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') = DATE_SUB(CURDATE(), INTERVAL 1 DAY)';
     } else {
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') = CURDATE()';
     }
@@ -342,8 +350,9 @@ if (isset($_GET['export_welcome_csv']) || isset($_GET['export_d3_csv']) || isset
 
     $isD7Export = isset($_GET['export_d7_csv']);
     $isD3Export = isset($_GET['export_d3_csv']);
-    $targetDate = new DateTimeImmutable($isD7Export ? 'today -7 days' : ($isD3Export ? 'today -3 days' : 'today'));
-    $filenamePrefix = $isD7Export ? 'D7_' : ($isD3Export ? 'D3_' : 'D1_');
+    $isD1Export = isset($_GET['export_d1_csv']);
+    $targetDate = new DateTimeImmutable($isD7Export ? 'today -7 days' : ($isD3Export ? 'today -3 days' : ($isD1Export ? 'today -1 day' : 'today')));
+    $filenamePrefix = $isD7Export ? 'D7_' : ($isD3Export ? 'D3_' : ($isD1Export ? 'D1_' : 'D0_'));
     $filename = $filenamePrefix . $targetDate->format('Y-m-d') . '.csv';
 
     header('Content-Type: text/csv; charset=UTF-8');
@@ -483,9 +492,10 @@ if (isset($_GET['export_welcome_csv']) || isset($_GET['export_d3_csv']) || isset
 <div class="wrapper">
     <div class="header-row">
         <h1>Estadísticas de usuarios de Linkaloo</h1>
-        <a class="welcome-export-btn" href="?export_welcome_csv=1">Descargar CSV usuarios D1 (sin favolinks)</a>
-        <a class="welcome-export-btn" href="?export_d3_csv=1">Descargar CSV usuarios D3 (sin favolinks)</a>
-        <a class="welcome-export-btn" href="?export_d7_csv=1">Descargar CSV usuarios D7 (sin favolinks)</a>
+        <a class="welcome-export-btn" href="?export_d0_csv=1" aria-label="Descargar CSV de usuarios D0 (sin favolinks)">⬇️ D0</a>
+        <a class="welcome-export-btn" href="?export_d1_csv=1" aria-label="Descargar CSV de usuarios D1 (sin favolinks)">⬇️ D1</a>
+        <a class="welcome-export-btn" href="?export_d3_csv=1" aria-label="Descargar CSV de usuarios D3 (sin favolinks)">⬇️ D3</a>
+        <a class="welcome-export-btn" href="?export_d7_csv=1" aria-label="Descargar CSV de usuarios D7 (sin favolinks)">⬇️ D7</a>
     </div>
 
     <div class="summary-grid">


### PR DESCRIPTION
### Motivation
- Hacer las exportaciones de usuarios más compactas y explícitas por día (D0/D1/D3/D7) y añadir un icono visual de descarga para facilitar su uso en la cabecera. 
- Añadir rutas de exportación explícitas para D0 y D1 para que los archivos generados tengan nombres y fechas coherentes.

### Description
- Modifiqué `linkaloo_stats.php` para aceptar `export_d0_csv` y `export_d1_csv` además de las rutas existentes `export_d3_csv` y `export_d7_csv` en la condición que dispara la generación del CSV. 
- Añadí la condición de fecha para `D1` como `DATE(...)=DATE_SUB(CURDATE(), INTERVAL 1 DAY)` y dejé `D0` mapeado a `today` (hoy). 
- Ajusté la lógica de nombre de archivo para elegir el prefijo `D0_`, `D1_`, `D3_` o `D7_` según la ruta solicitada y calcular la `targetDate` correspondiente. 
- Reemplacé los enlaces largos de la cabecera por botones compactos con icono y `aria-label`: `<a class="welcome-export-btn" href="?export_d0_csv=1" aria-label="Descargar CSV de usuarios D0 (sin favolinks)">⬇️ D0</a>` y equivalentes para `D1`, `D3`, `D7`.

### Testing
- Ejecuté `php -l linkaloo_stats.php` y no se reportaron errores de sintaxis (pasó). 
- Levanté un servidor de desarrollo con `php -S 0.0.0.0:8000 -t /workspace/linkaloo.com` y la página cargó correctamente (usado para validación visual). 
- Automatizé una captura de pantalla con Playwright del archivo `linkaloo_stats.php` en ejecución para confirmar los botones visuales y la interacción (captura generada con éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ce0d8ca0832c9451a2ee9eef7314)