### PR TITLE
Añade exportación D14 y botón en estadísticas

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -307,6 +307,7 @@ if (
     || isset($_GET['export_d1_csv'])
     || isset($_GET['export_d3_csv'])
     || isset($_GET['export_d7_csv'])
+    || isset($_GET['export_d14_csv'])
 ) {
     if (!$userCreatedColumn) {
         header('HTTP/1.1 500 Internal Server Error');
@@ -321,7 +322,9 @@ if (
     $csvCreatedSelect = "u.`{$userCreatedColumn}`";
     $csvUpdatedSelect = $userUpdatedColumn ? "u.`{$userUpdatedColumn}`" : 'NULL';
 
-    if (isset($_GET['export_d7_csv'])) {
+    if (isset($_GET['export_d14_csv'])) {
+        $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') BETWEEN DATE_SUB(CURDATE(), INTERVAL 14 DAY) AND DATE_SUB(CURDATE(), INTERVAL 8 DAY)';
+    } elseif (isset($_GET['export_d7_csv'])) {
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') BETWEEN DATE_SUB(CURDATE(), INTERVAL 7 DAY) AND DATE_SUB(CURDATE(), INTERVAL 3 DAY)';
     } elseif (isset($_GET['export_d3_csv'])) {
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') = DATE_SUB(CURDATE(), INTERVAL 3 DAY)';
@@ -348,11 +351,12 @@ if (
 
     $welcomeUsers = $pdo->query($welcomeUsersSql)->fetchAll(PDO::FETCH_ASSOC);
 
+    $isD14Export = isset($_GET['export_d14_csv']);
     $isD7Export = isset($_GET['export_d7_csv']);
     $isD3Export = isset($_GET['export_d3_csv']);
     $isD1Export = isset($_GET['export_d1_csv']);
-    $targetDate = new DateTimeImmutable($isD7Export ? 'today -7 days' : ($isD3Export ? 'today -3 days' : ($isD1Export ? 'today -1 day' : 'today')));
-    $filenamePrefix = $isD7Export ? 'D7_' : ($isD3Export ? 'D3_' : ($isD1Export ? 'D1_' : 'D0_'));
+    $targetDate = new DateTimeImmutable($isD14Export ? 'today -14 days' : ($isD7Export ? 'today -7 days' : ($isD3Export ? 'today -3 days' : ($isD1Export ? 'today -1 day' : 'today'))));
+    $filenamePrefix = $isD14Export ? 'D14_' : ($isD7Export ? 'D7_' : ($isD3Export ? 'D3_' : ($isD1Export ? 'D1_' : 'D0_')));
     $filename = $filenamePrefix . $targetDate->format('Y-m-d') . '.csv';
 
     header('Content-Type: text/csv; charset=UTF-8');
@@ -496,6 +500,7 @@ if (
         <a class="welcome-export-btn" href="?export_d1_csv=1" aria-label="Descargar CSV de usuarios D1 (sin favolinks)">⬇️ D1</a>
         <a class="welcome-export-btn" href="?export_d3_csv=1" aria-label="Descargar CSV de usuarios D3 (sin favolinks)">⬇️ D3</a>
         <a class="welcome-export-btn" href="?export_d7_csv=1" aria-label="Descargar CSV de usuarios D7 (sin favolinks)">⬇️ D7</a>
+        <a class="welcome-export-btn" href="?export_d14_csv=1" aria-label="Descargar CSV de usuarios D14 (registrados entre hace 8 y 14 días, sin favolinks)">⬇️ D14</a>
     </div>
 
     <div class="summary-grid">


### PR DESCRIPTION
### Motivation
- Permitir exportar usuarios sin favolinks que se registraron entre hace 8 y 14 días para campañas/seguimiento, integrando este rango en la página de estadísticas.

### Description
- Añade el parámetro de exportación `export_d14_csv` en `linkaloo_stats.php` y el `WHERE` que filtra por `DATE(...) BETWEEN DATE_SUB(CURDATE(), INTERVAL 14 DAY) AND DATE_SUB(CURDATE(), INTERVAL 8 DAY)`.
- Introduce la variable `isD14Export` y ajusta la lógica de `DateTimeImmutable` y prefijo de nombre de archivo para producir `D14_YYYY-MM-DD.csv`.
- Agrega el botón visual `⬇️ D14` en la cabecera de la página de estadísticas para descargar ese CSV.

### Testing
- Ejecuté `php -l linkaloo_stats.php` y no se detectaron errores de sintaxis (éxito).
- Intenté levantar el servidor embebido de PHP y hacer `curl` a `linkaloo_stats.php`, pero el servidor local no respondió en este entorno (fallido).
- Intenté capturar una pantalla con Playwright para validar la UI, pero la petición devolvió `ERR_EMPTY_RESPONSE` porque el servidor no quedó accesible (fallido).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6cf56793c832c866624ad5b06b07d)