### PR TITLE
Limitar exportación CSV a columnas ID y email en linkaloo_stats.php

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -122,8 +122,6 @@ foreach ($segments as $segment) {
 }
 
 $userCreatedColumn = pickColumn($pdo, 'usuarios', ['creado_en', 'created_at', 'fecha_creacion', 'registrado_en']);
-$userUpdatedColumn = pickColumn($pdo, 'usuarios', ['actualizado_en', 'updated_at', 'fecha_actualizacion', 'modificado_en']);
-$userNameColumn = pickColumn($pdo, 'usuarios', ['nombre', 'name', 'username']);
 $userEmailColumn = pickColumn($pdo, 'usuarios', ['email', 'correo', 'mail']);
 $lastAccessColumn = pickColumn($pdo, 'usuarios', ['ultimo_acceso', 'last_access', 'ultimo_login', 'last_login_at']);
 $linkCreatedColumn = pickColumn($pdo, 'links', ['creado_en', 'created_at', 'fecha_creacion']);
@@ -318,10 +316,8 @@ if (
     }
 
     $csvIdSelect = 'u.id';
-    $csvNameSelect = $userNameColumn ? "u.`{$userNameColumn}`" : "''";
     $csvEmailSelect = $userEmailColumn ? "u.`{$userEmailColumn}`" : "''";
     $csvCreatedSelect = "u.`{$userCreatedColumn}`";
-    $csvUpdatedSelect = $userUpdatedColumn ? "u.`{$userUpdatedColumn}`" : 'NULL';
 
     if (isset($_GET['export_reactivate_csv'])) {
         $registrationDateCondition = 'DATE(' . $csvCreatedSelect . ') < DATE_SUB(CURDATE(), INTERVAL 14 DAY)';
@@ -340,14 +336,11 @@ if (
     $welcomeUsersSql = "
         SELECT
             {$csvIdSelect} AS id,
-            {$csvNameSelect} AS nombre,
-            {$csvEmailSelect} AS email,
-            {$csvCreatedSelect} AS creado_en,
-            {$csvUpdatedSelect} AS actualizado_en
+            {$csvEmailSelect} AS email
         FROM usuarios u
         LEFT JOIN links l ON l.usuario_id = u.id
         WHERE {$registrationDateCondition}
-        GROUP BY u.id, nombre, email, creado_en, actualizado_en
+        GROUP BY u.id, email
         HAVING COUNT(l.id) = 0
         ORDER BY u.id ASC
     ";
@@ -379,15 +372,12 @@ if (
     }
 
     fwrite($output, "\xEF\xBB\xBF");
-    writePlainCsvRow($output, ['id', 'nombre', 'email', 'creado_en', 'actualizado_en']);
+    writePlainCsvRow($output, ['id', 'email']);
 
     foreach ($welcomeUsers as $user) {
         $row = [
             (string) ((int) ($user['id'] ?? 0)),
-            (string) ($user['nombre'] ?? ''),
             (string) ($user['email'] ?? ''),
-            (string) ($user['creado_en'] ?? ''),
-            (string) ($user['actualizado_en'] ?? ''),
         ];
 
         writePlainCsvRow($output, $row);


### PR DESCRIPTION
### Motivation
- Limitar la información exportada para los listados de usuarios sin favolinks a solo las columnas necesarias (`id` y `email`) y evitar incluir campos adicionales innecesarios.

### Description
- Se modificó el `SELECT` de exportación para que devuelva únicamente `id` y `email`, se actualizó el encabezado del CSV a `['id','email']` y se ajustaron las filas a exportar solo esos dos valores; además se eliminaron variables relacionadas con `nombre` y `actualizado_en` que ya no se usan.

### Testing
- Se ejecutó `php -l linkaloo_stats.php` y la comprobación de sintaxis devolvió "No syntax errors detected" (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d839b20c832cad44f11b4d0f7e09)