### PR TITLE
Evitar error 500 al guardar favolinks: protecciones en procesamiento de imágenes

### DIFF
--- a/image_utils.php
+++ b/image_utils.php
@@ -42,23 +42,43 @@ function saveImageFromUrl($url, $userId){
                 imagedestroy($img);
                 $final = $resized;
             }
-            imageresolution($final, 75, 75);
+            if(function_exists('imageresolution')){
+                imageresolution($final, 75, 75);
+            }
+
+            $saved = false;
             switch($ext){
                 case 'png':
-                    imagepng($final, $fullPath);
+                    if(function_exists('imagepng')){
+                        $saved = imagepng($final, $fullPath);
+                    }
                     break;
                 case 'gif':
-                    imagegif($final, $fullPath);
+                    if(function_exists('imagegif')){
+                        $saved = imagegif($final, $fullPath);
+                    }
                     break;
                 case 'webp':
-                    imagewebp($final, $fullPath);
+                    if(function_exists('imagewebp')){
+                        $saved = imagewebp($final, $fullPath);
+                    }
                     break;
                 case 'bmp':
-                    imagebmp($final, $fullPath);
+                    if(function_exists('imagebmp')){
+                        $saved = imagebmp($final, $fullPath);
+                    }
                     break;
                 default:
-                    imagejpeg($final, $fullPath, 85);
+                    if(function_exists('imagejpeg')){
+                        $saved = imagejpeg($final, $fullPath, 85);
+                    }
                     break;
+            }
+
+            if(!$saved && function_exists('imagejpeg')){
+                $fullPath = preg_replace('/\.[^.]+$/', '.jpg', $fullPath);
+                $filename = preg_replace('/\.[^.]+$/', '.jpg', $filename);
+                imagejpeg($final, $fullPath, 85);
             }
             imagedestroy($final);
         } else {


### PR DESCRIPTION
### Motivation
- Guardar un link puede descargar y procesar una imagen remota, y en entornos donde faltan funciones GD esto provocaba errores fatales (HTTP 500).
- Se busca hacer el flujo de guardado resiliente para que la falta de encoders o funciones de transformación no impida guardar el link.

### Description
- En `saveImageFromUrl` se protege la llamada a `imageresolution` con `function_exists('imageresolution')` para evitar llamadas a funciones inexistentes.
- Se añadió verificación con `function_exists` antes de llamar a cada encoder (`imagepng`, `imagegif`, `imagewebp`, `imagebmp`, `imagejpeg`) y se registra el resultado en la variable `$saved` para detectar fallos de guardado.
- Se implementó un fallback seguro que fuerza a guardar en JPEG cuando el encoder del formato original no está disponible, actualizando la extensión de archivo para mantener coherencia.
- Se preserva el comportamiento previo de redimensionado y devolución de la ruta `/fichas/<userId>/<filename>` incluso si el encoder nativo falta, evitando interrumpir el flujo de guardado del link.

### Testing
- Se ejecutó `php -l image_utils.php` y el chequeo de sintaxis retornó sin errores.
- Se ejecutó `php -l agregar_favolink.php` y el chequeo de sintaxis retornó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7abc6e2dc832c87d321a34e8f3dbc)