### PR TITLE
Incluir usuarios con 0 links en barra de segmentos

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -484,15 +484,13 @@ foreach ($segments as $segment) {
         'short_label' => $segmentLegends[$key],
     ];
 
-    if ($key !== 'usuarios_sin_links') {
-        $barChartRows[] = [
-            'title' => $segmentTitles[$key],
-            'usuarios' => $segmentUsers,
-            'pct_users' => $segmentUsersPct,
-            'color' => $segmentColors[$key],
-            'short_label' => $segmentLegends[$key],
-        ];
-    }
+    $barChartRows[] = [
+        'title' => $segmentTitles[$key],
+        'usuarios' => $segmentUsers,
+        'pct_users' => $segmentUsersPct,
+        'color' => $segmentColors[$key],
+        'short_label' => $segmentLegends[$key],
+    ];
 }
 
 foreach ($segmentsForCharts as $segment) {


### PR DESCRIPTION
### Motivation
- El gráfico "Cantidad y % de Usuarios por favolinks guardados" debía mostrar también el segmento de usuarios que tienen 0 favolinks para reflejar correctamente la distribución.

### Description
- Se modificó la generación de `barChartRows` en `linkaloo_stats.php` para no excluir el segmento `usuarios_sin_links` y así incluirlo en el gráfico. 
- Se eliminó la condición que filtraba `usuarios_sin_links` y ahora todos los segmentos de `statsSegments()` se añaden a `barChartRows`.

### Testing
- Se ejecutó `php -l linkaloo_stats.php` y no se detectaron errores de sintaxis (comprobación exitosa).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c574379024832c8826f72c1bb5eff7)