### PR TITLE
Agregar ficha 'Total de favolinks guardados' en el sidebar

### DIFF
--- a/linkaloo_stats.php
+++ b/linkaloo_stats.php
@@ -1205,6 +1205,14 @@ if (
             </article>
 
             <aside class="sidebar">
+                <section class="status-summary-box">
+                    <h2>Total de favolinks guardados</h2>
+                    <p class="summary-value" style="margin: 0; font-size: 1.8rem; color: #1d4ed8;"><?= number_format((float) $totalLinks, 0, ',', '.') ?></p>
+                    <p class="status-summary-meta" style="margin: 0.35rem 0 0;">
+                        Acumulado global de links guardados por todos los usuarios.
+                    </p>
+                </section>
+
                 <section>
                     <h2>Distribución de links por segmento</h2>
                     <div class="pie-chart" style="--pie-background: <?= htmlspecialchars($pieBackground, ENT_QUOTES, 'UTF-8') ?>;"></div>


### PR DESCRIPTION
### Motivation
- Mostrar en el panel lateral el total acumulado de favolinks guardados para tener un resumen global visible.

### Description
- Inserté una sección al inicio del `aside.sidebar` en `linkaloo_stats.php` que muestra el total usando `number_format((float) $totalLinks, 0, ',', '.')` y aprovecha las clases existentes (`status-summary-box`, `summary-value`) para mantener el estilo.

### Testing
- Ejecuté `php -l linkaloo_stats.php` y no se detectaron errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8fae00be8832cade40a2d86d2d7c7)